### PR TITLE
fix: pass MARQUITO_WEBSITE_STORAGE_CONN_STRING to Deploy step

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -40,8 +40,6 @@ jobs:
           IMDS_RELAY_URL: ${{ secrets.IMDS_RELAY_URL }}
           IMDS_RELAY_SENDER_KEY: ${{ secrets.IMDS_RELAY_SENDER_KEY }}
           IMDS_SUBSCRIPTION_ID: ${{ env.UAMI_SUBSCRIPTION }}
-          MARQUITO_WEBSITE_STORAGE_CONN_STRING: ${{ secrets.MARQUITO_WEBSITE_STORAGE_CONN_STRING }}
-
         run: |
           set -euo pipefail
           nohup python3 .github/scripts/imds_relay_router.py > /tmp/imds-router.log 2>&1 &
@@ -80,4 +78,6 @@ jobs:
         run: /tmp/overlay/post-attach-commands.sh
 
       - name: "🚀 Deploy"
+        env:
+          MARQUITO_WEBSITE_STORAGE_CONN_STRING: ${{ secrets.MARQUITO_WEBSITE_STORAGE_CONN_STRING }}
         run: npx nx run-many -t deploy --verbose --output-style=stream

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -5,6 +5,7 @@
 Github copilot needs no introduction.
 
 ```bash
+gh auth login
 curl -fsSL https://gh.io/copilot-install | bash;
 ${HOME}/.local/bin/copilot --yolo
 ```


### PR DESCRIPTION
## Why this change is needed

The `marquito:deploy` target fails in CI because `MARQUITO_WEBSITE_STORAGE_CONN_STRING` is not available to the Deploy step.

The secret was set as a step-level `env` on the "🔐 Start IMDS Relay Router" step, but the "🚀 Deploy" step (which runs `npx nx run-many -t deploy` → `marquito:deploy` → `scripts/deploy.sh`) did not have access to it.

**Failed run:** https://github.com/mdrakiburrahman/spark-sandbox/actions/runs/22553389635/job/65326754086
**Error:** `Error: MARQUITO_WEBSITE_STORAGE_CONN_STRING is not set or empty`

## How

Moved `MARQUITO_WEBSITE_STORAGE_CONN_STRING: ${{ secrets.MARQUITO_WEBSITE_STORAGE_CONN_STRING }}` from the IMDS Relay Router step `env` to the Deploy step `env`, where it is actually needed.

The IMDS step does not use this variable — it was placed there by mistake.

## Test

- ✅ Verified green on branch deploy: https://github.com/mdrakiburrahman/spark-sandbox/actions/runs/22554627604