### PR TITLE
feat: Added a Fabric pipeline killer

### DIFF
--- a/contrib/bootstrap-dev-env.ps1
+++ b/contrib/bootstrap-dev-env.ps1
@@ -71,5 +71,5 @@ wsl --shutdown
 
 winget install -e --id Microsoft.GitCredentialManagerCore
 
-Write-Host "Installing Ubuntu-24.04"
-wsl --install -d Ubuntu-24.04
+Write-Host "Installing Ubuntu"
+wsl --install -d Ubuntu

--- a/projects/fabric/workspace-automation/.gitignore
+++ b/projects/fabric/workspace-automation/.gitignore
@@ -1,0 +1,28 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+dist/
+build/
+*.egg
+
+# Virtual environments
+.venv/
+
+# PyInstaller
+*.spec.bak
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Coverage
+.coverage
+htmlcov/

--- a/projects/fabric/workspace-automation/.scripts/hatch.sh
+++ b/projects/fabric/workspace-automation/.scripts/hatch.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${PROJECT_DIR}"
+
+TARGET="${1:-}"
+shift || true
+
+case "${TARGET}" in
+  env)
+    # Create the hatch environment
+    hatch env create "${@}"
+    ;;
+  build)
+    # Run hatch build scripts
+    hatch run build:"${@}"
+    ;;
+  run)
+    # Run arbitrary hatch commands
+    hatch run "${@}"
+    ;;
+  clean)
+    # Clean all Python state: hatch envs, build artifacts, caches
+    rm -rf .venv build dist *.egg-info .pytest_cache .mypy_cache .ruff_cache .coverage htmlcov
+    hatch env prune 2>/dev/null || true
+    rm -rf ~/.local/share/hatch/env/virtual/workspace-automation 2>/dev/null || true
+    find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+    ;;
+  *)
+    echo "Usage: hatch.sh {env|build|run|clean} [args...]"
+    exit 1
+    ;;
+esac

--- a/projects/fabric/workspace-automation/.scripts/run.sh
+++ b/projects/fabric/workspace-automation/.scripts/run.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+CLI="./dist/workspace-automation"
+CONFIG="../config/workspace/deployment/dev.json"
+WORKSPACE_ID="3ea60ae5-e979-4d31-a317-66491ab497fb"
+PIPELINE_NAME="demo_etl"
+
+# ── Args ──────────────────────────────────────────────────────────────────────
+COMMAND="${1:?Usage: run.sh <command> [flags...]}"
+shift
+
+$CLI "$COMMAND" \
+  --workspace-id "$WORKSPACE_ID" \
+  --pipeline-name "$PIPELINE_NAME" \
+  --config "$CONFIG" \
+  "$@"

--- a/projects/fabric/workspace-automation/README.md
+++ b/projects/fabric/workspace-automation/README.md
@@ -1,0 +1,11 @@
+# workspace-automation
+
+CLI for ad-hoc Fabric workspace operations.
+
+## Quick Start
+
+> Requires `az login` first.
+
+```bash
+npx nx run workspace-automation:run --COMMAND=kill-pipeline
+```

--- a/projects/fabric/workspace-automation/project.json
+++ b/projects/fabric/workspace-automation/project.json
@@ -1,0 +1,73 @@
+{
+  "name": "workspace-automation",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "targets": {
+    "clean": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          "rm -rf .venv .venv-build build dist *.egg-info .pytest_cache .mypy_cache .ruff_cache .coverage htmlcov",
+          "hatch env prune 2>/dev/null || true",
+          "rm -rf ~/.local/share/hatch/env/virtual/workspace-automation 2>/dev/null || true",
+          "find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true"
+        ],
+        "cwd": "projects/fabric/workspace-automation"
+      }
+    },
+    "install": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          "bash .scripts/hatch.sh env"
+        ],
+        "cwd": "projects/fabric/workspace-automation"
+      }
+    },
+    "build": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["install"],
+      "options": {
+        "commands": [
+          "bash .scripts/hatch.sh build binary"
+        ],
+        "cwd": "projects/fabric/workspace-automation"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["install"],
+      "options": {
+        "commands": [
+          "bash .scripts/hatch.sh run test"
+        ],
+        "cwd": "projects/fabric/workspace-automation"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["install"],
+      "options": {
+        "commands": [
+          "bash .scripts/hatch.sh run lint-check"
+        ],
+        "cwd": "projects/fabric/workspace-automation"
+      }
+    },
+    "run": {
+      "cache": false,
+      "executor": "nx:run-commands",
+      "dependsOn": ["build"],
+      "options": {
+        "COMMAND": "kill-pipeline",
+        "commands": [
+          {
+            "command": "bash .scripts/run.sh {args.COMMAND} --verbose",
+            "forwardAllArgs": false
+          }
+        ],
+        "cwd": "projects/fabric/workspace-automation"
+      }
+    }
+  }
+}

--- a/projects/fabric/workspace-automation/pyproject.toml
+++ b/projects/fabric/workspace-automation/pyproject.toml
@@ -1,0 +1,77 @@
+[build-system]
+requires = ["hatchling>=1.17.0"]
+build-backend = "hatchling.build"
+
+[project]
+name = "workspace-automation"
+dynamic = ["version"]
+description = "CLI tool for Microsoft Fabric workspace automation tasks"
+readme = "README.md"
+requires-python = ">=3.11"
+license = {text = "MIT"}
+authors = [
+  { name = "Raki Rahman", email = "mdrakiburrahman@gmail.com" },
+]
+dependencies = [
+  "click>=8.1.0",
+  "fabric-cicd @ https://rakirahman.blob.core.windows.net/public/whls/fabric_cicd-0.1.34.3-py3-none-any.whl",
+  "fabric-workspace-deployment @ git+https://github.com/mdrakiburrahman/fabric-workspace-deployment.git@8b4388b112ab0b4e8088edf2f1cadedc7dc9e193",
+]
+
+[project.scripts]
+workspace-automation = "workspace_automation.cli:main"
+
+[project.urls]
+Source = "https://github.com/mdrakiburrahman/spark-sandbox"
+
+[tool.hatch.metadata]
+allow-direct-references = true
+
+[tool.hatch.version]
+source = "code"
+path = "src/workspace_automation/__about__.py"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/workspace_automation"]
+
+[tool.hatch.envs.default]
+type = "virtual"
+path = ".venv"
+installer = "uv"
+dependencies = [
+  "pytest>=9.0.0",
+  "black",
+]
+
+[tool.hatch.envs.default.scripts]
+test = "pytest {args:tests}"
+lint-check = "black --check ."
+lint-format = "black ."
+
+[tool.hatch.envs.build]
+path = ".venv-build"
+dependencies = [
+  "pyinstaller>=6.0.0",
+]
+
+[tool.hatch.envs.build.scripts]
+binary = "pyinstaller workspace-automation.spec"
+clean = "rm -rf build dist"
+
+[tool.black]
+line-length = 300
+
+[tool.coverage.run]
+source_pkgs = ["workspace_automation", "tests"]
+branch = true
+parallel = true
+omit = [
+  "src/workspace_automation/__about__.py",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+  "no cov",
+  "if __name__ == .__main__.:",
+  "if TYPE_CHECKING:",
+]

--- a/projects/fabric/workspace-automation/src/workspace_automation/__about__.py
+++ b/projects/fabric/workspace-automation/src/workspace_automation/__about__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: MIT
+__version__ = "0.1.0"

--- a/projects/fabric/workspace-automation/src/workspace_automation/__init__.py
+++ b/projects/fabric/workspace-automation/src/workspace_automation/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: MIT

--- a/projects/fabric/workspace-automation/src/workspace_automation/cli.py
+++ b/projects/fabric/workspace-automation/src/workspace_automation/cli.py
@@ -1,0 +1,128 @@
+import asyncio
+import json
+import logging
+import sys
+
+import click
+
+from workspace_automation.__about__ import __version__
+
+
+def setup_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+    )
+
+
+def create_factory(config_path: str):
+    """Create a ContainerizedManagementFactory from a config file."""
+    from fabric_workspace_deployment.factories.management_factory import ContainerizedManagementFactory
+    from fabric_workspace_deployment.operations.operation_interfaces import OperationParams
+
+    operation_params = OperationParams(
+        config_file_absolute_path=config_path,
+        operation="dryRun",
+        replace_placeholders=True,
+    )
+    return ContainerizedManagementFactory(operation_params)
+
+
+async def _kill_pipeline(pipeline_client, run_client, workspace_id: str, pipeline_name: str) -> dict:
+    """Kill all non-terminal runs of a named pipeline. Returns result dict."""
+    logger = logging.getLogger(__name__)
+
+    # Resolve pipeline by name
+    pipeline = await pipeline_client.get_pipeline(workspace_id, pipeline_name)
+    if pipeline is None:
+        raise click.ClickException(f"Pipeline '{pipeline_name}' not found in workspace '{workspace_id}'")
+
+    pipeline_id = pipeline.object_id
+    logger.info(f"Found pipeline '{pipeline.display_name}' (id: {pipeline_id})")
+
+    # List non-terminal runs
+    runs = await run_client.list_non_terminal_runs(workspace_id, pipeline_id)
+    if not runs:
+        logger.info("No non-terminal runs found — nothing to cancel")
+        return {
+            "pipeline_name": pipeline.display_name,
+            "pipeline_id": pipeline_id,
+            "workspace_id": workspace_id,
+            "cancelled": [],
+            "failed": [],
+            "total_found": 0,
+        }
+
+    logger.info(f"Found {len(runs)} non-terminal run(s) to cancel")
+
+    cancelled = []
+    failed = []
+
+    for run in runs:
+        run_id = run.artifact_job_instance_id
+        logger.info(f"Cancelling run {run_id} (status: {run.status_string})")
+        try:
+            success = await run_client.cancel_run(workspace_id, pipeline_id, run_id)
+            if success:
+                cancelled.append({"run_id": run_id, "status": run.status_string})
+                logger.info(f"Successfully cancelled run {run_id}")
+            else:
+                failed.append({"run_id": run_id, "status": run.status_string, "reason": "API returned non-202 status"})
+                logger.warning(f"Failed to cancel run {run_id}")
+        except Exception as e:
+            failed.append({"run_id": run_id, "status": run.status_string, "reason": str(e)})
+            logger.error(f"Error cancelling run {run_id}: {e}")
+
+    return {
+        "pipeline_name": pipeline.display_name,
+        "pipeline_id": pipeline_id,
+        "workspace_id": workspace_id,
+        "cancelled": cancelled,
+        "failed": failed,
+        "total_found": len(runs),
+    }
+
+
+@click.group()
+@click.version_option(version=__version__, prog_name="workspace-automation")
+def cli():
+    """Microsoft Fabric workspace automation CLI."""
+    pass
+
+
+@cli.command("kill-pipeline")
+@click.option("--workspace-id", required=True, help="Fabric workspace object ID.")
+@click.option("--pipeline-name", required=True, help="Display name of the pipeline to kill.")
+@click.option("--config", required=True, type=click.Path(exists=True), help="Path to config JSON file.")
+@click.option("--verbose", "-v", is_flag=True, default=False, help="Enable verbose logging.")
+def kill_pipeline(workspace_id: str, pipeline_name: str, config: str, verbose: bool):
+    """Kill all Not Started or Running instances of a named pipeline."""
+    setup_logging(verbose)
+    logger = logging.getLogger(__name__)
+
+    try:
+        factory = create_factory(config)
+        pipeline_client = factory.create_fabric_pipeline_client()
+        run_client = factory.create_fabric_pipeline_run_client()
+        result = asyncio.run(_kill_pipeline(pipeline_client, run_client, workspace_id, pipeline_name))
+
+        click.echo(json.dumps(result, indent=2))
+
+        if result["failed"]:
+            sys.exit(1)
+
+    except click.ClickException:
+        raise
+    except Exception as e:
+        logger.error(f"Unexpected error: {e}")
+        raise click.ClickException(str(e))
+
+
+def main():
+    cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/fabric/workspace-automation/tests/test_cli.py
+++ b/projects/fabric/workspace-automation/tests/test_cli.py
@@ -1,0 +1,112 @@
+import asyncio
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import click
+import pytest
+
+from workspace_automation.cli import _kill_pipeline
+
+
+@dataclass
+class MockPipeline:
+    id: str
+    object_id: str
+    display_name: str
+
+
+@dataclass
+class MockPipelineRun:
+    artifact_job_instance_id: str
+    status: int
+    status_string: str
+
+
+class TestKillPipeline:
+    """Tests for the _kill_pipeline async function."""
+
+    @pytest.fixture
+    def mock_pipeline_client(self):
+        client = MagicMock()
+        client.get_pipeline = AsyncMock()
+        return client
+
+    @pytest.fixture
+    def mock_run_client(self):
+        client = MagicMock()
+        client.list_non_terminal_runs = AsyncMock()
+        client.cancel_run = AsyncMock()
+        return client
+
+    def test_pipeline_not_found(self, mock_pipeline_client, mock_run_client):
+        """Should raise ClickException when pipeline name doesn't resolve."""
+        mock_pipeline_client.get_pipeline.return_value = None
+
+        with pytest.raises(click.ClickException, match="not found"):
+            asyncio.run(_kill_pipeline(mock_pipeline_client, mock_run_client, "ws-123", "nonexistent-pipeline"))
+
+        mock_pipeline_client.get_pipeline.assert_awaited_once_with("ws-123", "nonexistent-pipeline")
+
+    def test_no_runs_to_cancel(self, mock_pipeline_client, mock_run_client):
+        """Should return empty cancelled list when no non-terminal runs exist."""
+        mock_pipeline_client.get_pipeline.return_value = MockPipeline(id="pipe-1", object_id="pipe-obj-1", display_name="my-pipeline")
+        mock_run_client.list_non_terminal_runs.return_value = []
+
+        result = asyncio.run(_kill_pipeline(mock_pipeline_client, mock_run_client, "ws-123", "my-pipeline"))
+
+        assert result["pipeline_name"] == "my-pipeline"
+        assert result["pipeline_id"] == "pipe-obj-1"
+        assert result["total_found"] == 0
+        assert result["cancelled"] == []
+        assert result["failed"] == []
+        mock_run_client.cancel_run.assert_not_awaited()
+
+    def test_cancels_all_runs(self, mock_pipeline_client, mock_run_client):
+        """Should cancel all non-terminal runs and report results."""
+        mock_pipeline_client.get_pipeline.return_value = MockPipeline(id="pipe-1", object_id="pipe-obj-1", display_name="my-pipeline")
+        mock_run_client.list_non_terminal_runs.return_value = [
+            MockPipelineRun(artifact_job_instance_id="run-1", status=0, status_string="Not Started"),
+            MockPipelineRun(artifact_job_instance_id="run-2", status=1, status_string="In Progress"),
+        ]
+        mock_run_client.cancel_run.return_value = True
+
+        result = asyncio.run(_kill_pipeline(mock_pipeline_client, mock_run_client, "ws-123", "my-pipeline"))
+
+        assert result["total_found"] == 2
+        assert len(result["cancelled"]) == 2
+        assert result["cancelled"][0]["run_id"] == "run-1"
+        assert result["cancelled"][1]["run_id"] == "run-2"
+        assert result["failed"] == []
+        assert mock_run_client.cancel_run.await_count == 2
+
+    def test_partial_failure(self, mock_pipeline_client, mock_run_client):
+        """Should report both cancelled and failed runs when some cancellations fail."""
+        mock_pipeline_client.get_pipeline.return_value = MockPipeline(id="pipe-1", object_id="pipe-obj-1", display_name="my-pipeline")
+        mock_run_client.list_non_terminal_runs.return_value = [
+            MockPipelineRun(artifact_job_instance_id="run-1", status=0, status_string="Not Started"),
+            MockPipelineRun(artifact_job_instance_id="run-2", status=1, status_string="In Progress"),
+        ]
+        mock_run_client.cancel_run.side_effect = [True, False]
+
+        result = asyncio.run(_kill_pipeline(mock_pipeline_client, mock_run_client, "ws-123", "my-pipeline"))
+
+        assert result["total_found"] == 2
+        assert len(result["cancelled"]) == 1
+        assert len(result["failed"]) == 1
+        assert result["cancelled"][0]["run_id"] == "run-1"
+        assert result["failed"][0]["run_id"] == "run-2"
+
+    def test_cancel_exception(self, mock_pipeline_client, mock_run_client):
+        """Should handle exceptions during cancellation gracefully."""
+        mock_pipeline_client.get_pipeline.return_value = MockPipeline(id="pipe-1", object_id="pipe-obj-1", display_name="my-pipeline")
+        mock_run_client.list_non_terminal_runs.return_value = [
+            MockPipelineRun(artifact_job_instance_id="run-1", status=1, status_string="In Progress"),
+        ]
+        mock_run_client.cancel_run.side_effect = RuntimeError("API timeout")
+
+        result = asyncio.run(_kill_pipeline(mock_pipeline_client, mock_run_client, "ws-123", "my-pipeline"))
+
+        assert result["total_found"] == 1
+        assert len(result["cancelled"]) == 0
+        assert len(result["failed"]) == 1
+        assert "API timeout" in result["failed"][0]["reason"]

--- a/projects/fabric/workspace-automation/workspace-automation.spec
+++ b/projects/fabric/workspace-automation/workspace-automation.spec
@@ -1,0 +1,43 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+a = Analysis(
+    ['src/workspace_automation/cli.py'],
+    pathex=[],
+    binaries=[],
+    datas=[],
+    hiddenimports=[
+        'click',
+        'fabric_cicd',
+        'fabric_workspace_deployment',
+        'fabric_workspace_deployment.factories.management_factory',
+        'fabric_workspace_deployment.operations.operation_interfaces',
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='workspace-automation',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/projects/spark.code-workspace
+++ b/projects/spark.code-workspace
@@ -30,8 +30,17 @@
   ],
   "settings": {
     "files.watcherExclude": {
-      "**/target": true
+      "**/target": true,
     },
     "java.compile.nullAnalysis.mode": "disabled",
+    "chat.agentSkillsLocations": {
+      ".github/skills": true,
+      ".agents/skills": true,
+      ".claude/skills": true,
+      "~/.copilot/skills": true,
+      "~/.agents/skills": true,
+      "~/.claude/skills": true,
+      "~/.vscode-server/extensions/synapsevscode.synapse-1.21.0/copilot/skills": true,
+    },
   },
 }


### PR DESCRIPTION
# Why this change is needed

As schedules trigger on Fabric, old pipelines build up and are impossible to cancel via UI.

# How

Add a small Python tool.

# Test

```bash
npx nx run workspace-automation:run --COMMAND=kill-pipeline
```

<img width="1246" height="900" alt="image" src="https://github.com/user-attachments/assets/c740cc6b-f8df-428d-bb1e-099732212376" />