### PR TITLE
refactor(spark-dbt): move test target down to per-sub-project nx projects

### DIFF
--- a/.github/skills/ci-green-runner/skill.md
+++ b/.github/skills/ci-green-runner/skill.md
@@ -157,13 +157,14 @@ Make all fixes before any commit:
 
 Classify changes to determine which local validation is needed:
 
-| Path pattern                  | Affected project | Local validation command                                         |
-| ----------------------------- | ---------------- | ---------------------------------------------------------------- |
-| `projects/spark-scala/**`     | spark-scala      | `cd projects/spark-scala && sbt test`                            |
-| `projects/spark-dbt/**`       | spark-dbt        | `npx nx run spark-dbt:run --PROJECT=<proj> --TARGET=local-local` |
-| `projects/spark-python/**`    | spark-python     | `npx nx run spark-python:test`                                   |
-| `projects/fabric/**`          | fabric           | No local tests available                                         |
-| `*.md`, `tools/**`, `docs/**` | none             | No validation needed                                             |
+| Path pattern                  | Affected project              | Local validation command                                         |
+| ----------------------------- | ----------------------------- | ---------------------------------------------------------------- |
+| `projects/spark-scala/**`     | spark-scala                   | `cd projects/spark-scala && sbt test`                            |
+| `projects/spark-dbt/dbt-*/**` | dbt-jaffle-shop / dbt-adventureworks / dbt-dataops | `npx nx run dbt-<name>:test --TARGET=local-local`   |
+| `projects/spark-dbt/**`       | spark-dbt (shared lifecycle)  | `npx nx affected -t test` (fans out to the affected dbt-* projects) |
+| `projects/spark-python/**`    | spark-python                  | `npx nx run spark-python:test`                                   |
+| `projects/fabric/**`          | fabric                        | No local tests available                                         |
+| `*.md`, `tools/**`, `docs/**` | none                          | No validation needed                                             |
 
 ---
 

--- a/.github/skills/dbt-to-power-bi/skill.md
+++ b/.github/skills/dbt-to-power-bi/skill.md
@@ -185,10 +185,10 @@ Add to the colocated `<model>.yml` (or `schema.yml`):
 
 ```bash
 # Run one sub-project end-to-end (default TARGET=local-local)
-npx nx run spark-dbt:run --PROJECT=dbt-<name>
+npx nx run dbt-<name>:test
 
 # All 3 sub-projects in parallel
-npx nx run spark-dbt:test
+npx nx run-many -t test --projects=dbt-jaffle-shop,dbt-adventureworks,dbt-dataops
 
 # Targeted partial-build (drop into hatch first)
 cd projects/spark-dbt && hatch shell && cd dbt-<name>

--- a/.github/skills/ralph-spark-dbt/skill.md
+++ b/.github/skills/ralph-spark-dbt/skill.md
@@ -110,15 +110,19 @@ npx nx run spark-dbt:lint
 
 ## Step 3: Run & Test dbt Projects
 
-The `test` target runs both dbt projects in parallel against the `local-local` target:
+Each dbt sub-project is its own Nx project with its own `test` target. Use `nx affected` (CI default) or `nx run-many` to run the relevant set in parallel against the `local-local` target:
 
 ```bash
-npx nx run spark-dbt:test
+# All 3 sub-projects
+npx nx run-many -t test --projects=dbt-jaffle-shop,dbt-adventureworks,dbt-dataops
+
+# Only the projects whose files changed since main
+npx nx affected -t test
 ```
 
 This executes the full dbt pipeline for each project: `dbt debug` → `dbt deps` → `dbt seed` (if applicable) → `dbt run` → `dbt test` → `dbt docs generate`.
 
-**Prerequisites**: The `test` target depends on `init`, which itself depends on `spark-scala:init` (Spark metastore must be running) and `spark-dbt:install`.
+**Prerequisites**: each per-sub-project `test` target depends on `spark-dbt:init`, which itself depends on `spark-scala:init` (Spark metastore must be running) and `spark-dbt:install`.
 
 ### Running a single dbt project
 
@@ -126,9 +130,13 @@ If only one project changed, run it individually to iterate faster:
 
 ```bash
 # Jaffle Shop only
-npx nx run spark-dbt:run --PROJECT=dbt-jaffle-shop --TARGET=local-local
+npx nx run dbt-jaffle-shop:test
 
 # Adventureworks only
+npx nx run dbt-adventureworks:test
+
+# Or via the root run target (ad-hoc, bypasses per-sub-project nx caching)
+npx nx run spark-dbt:run --PROJECT=dbt-jaffle-shop --TARGET=local-local
 npx nx run spark-dbt:run --PROJECT=dbt-adventureworks --TARGET=local-local
 ```
 

--- a/.github/workflows/gci.yaml
+++ b/.github/workflows/gci.yaml
@@ -76,7 +76,7 @@ jobs:
         run: /tmp/overlay/post-attach-commands.sh
 
       - name: "🧹 Clean Projects"
-        run: npx nx affected --base=origin/main -t clean --parallel=3 --output-style=stream
+        run: npx nx run-many -t clean --all --parallel=3 --output-style=stream
 
       - name: "🔧 Init Projects"
         run: npx nx affected --base=origin/main -t init --parallel=3 --output-style=stream

--- a/projects/spark-dbt/.github/copilot-instructions.md
+++ b/projects/spark-dbt/.github/copilot-instructions.md
@@ -13,7 +13,7 @@ These are the conventions and architecture facts that apply to **every** change 
 projects/spark-dbt/
 ├── README.md                     # devbox bootstrap, hatch shell, nx targets
 ├── pyproject.toml                # hatch venv; pinned dbt-fabricspark==1.9.5 (uv installer)
-├── project.json                  # nx targets: clean, install, init, run, package, compile, test
+├── project.json                  # nx root: clean, install, init, run, package, compile, lint
 ├── .scripts/
 │   ├── run-dbt-local.sh          # one-project loop: debug → deps → seed → build → cleanup → docs
 │   ├── package-fabric.sh         # packages all dbt projects into a Fabric deploy bundle
@@ -26,7 +26,7 @@ projects/spark-dbt/
 └── dbt-dataops/                  # Delta Lake KPI STAR schema (dim_* / fct_*, includes snapshots)
 ```
 
-All 3 `dbt-*/` directories are managed by the **single** `spark-dbt` Nx project — there is no per-sub-project `project.json`. Sub-projects are selected via the `--PROJECT=` arg to `npx nx run spark-dbt:run`.
+All 3 `dbt-*/` directories are first-class Nx projects with their **own** `project.json` exposing a `test` target, so `nx affected -t test` only runs the sub-project whose files actually changed. The root `spark-dbt` Nx project owns the shared lifecycle (`clean`, `install`, `init`, `run`, `package`, `compile`, `lint`) and the shared hatch venv; `dbt-<name>/project.json::test` declares `dependsOn: [{ target: "init", projects: ["spark-dbt"], params: "ignore" }]` so the venv is provisioned once before the per-sub-project run.
 
 ---
 
@@ -40,6 +40,7 @@ dbt-<name>/
 ├── packages.yml                  # dbt deps (dbt_utils, dbt_date, etc.)
 ├── package-lock.yml              # pinned dep versions
 ├── profiles.yml                  # local-local | local-fabric | fabric-fabric targets (see §6)
+├── project.json                  # nx targets: test (depends on spark-dbt:init, params="ignore")
 ├── README.md                     # project-specific connectivity + run instructions
 │
 ├── models/
@@ -125,32 +126,37 @@ dbt-<name>/
 
 ## 4. Nx targets
 
-A single `spark-dbt` Nx project drives all 3 dbt sub-projects via `--PROJECT=` and `--TARGET=`:
+The `spark-dbt` workspace splits responsibilities. The root `spark-dbt` project owns the shared lifecycle (hatch venv, scripts, deploy bundle); each `dbt-<name>/` is its own Nx project that owns its `test` target:
 
-| Target    | Owns                                                | Notes                                                   |
-| --------- | --------------------------------------------------- | ------------------------------------------------------- |
-| `clean`   | hatch env teardown + `.cleanpaths` rm               | Refuses to run inside a `hatch shell` (errors out)      |
-| `install` | `hatch env create` (depends on `clean`)             | Creates `.venv/` via uv                                 |
-| `init`    | depends on `spark-scala:init` + `install`           | One-time devbox bootstrap                               |
-| `run`     | `.scripts/run-dbt-local.sh {PROJECT} {TARGET}`      | Default `PROJECT=dbt-jaffle-shop`, `TARGET=local-local` |
-| `test`    | runs all 3 sub-projects in parallel via `:run`      | Depends on `init`                                       |
-| `package` | `.scripts/package-fabric.sh`                        | Builds a single Fabric deploy bundle                    |
-| `compile` | `.scripts/compile-erd.sh`                           | Regenerates `dbt-<name>/erd/*.md` via `dbterd`          |
-| `lint`    | `black --line-length 2000 .` (defined at repo root) | No `sqlfluff` here — Python-only lint                   |
+| Nx project           | Owns                                                                 | Targets                                                       |
+| -------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------- |
+| `spark-dbt`          | shared lifecycle (`.scripts/`, `pyproject.toml`, hatch, `lint`)      | `clean`, `install`, `init`, `run`, `package`, `compile`, `lint` |
+| `dbt-jaffle-shop`    | `dbt-jaffle-shop/**`                                                 | `test`                                                        |
+| `dbt-adventureworks` | `dbt-adventureworks/**`                                              | `test`                                                        |
+| `dbt-dataops`        | `dbt-dataops/**`                                                     | `test`                                                        |
+
+Each per-sub-project `test` invokes `.scripts/run-dbt-local.sh <project> {args.TARGET}` (default `TARGET=local-local`) and depends on `spark-dbt:init` (`params: "ignore"`) so the shared hatch venv is set up first. Lint (`black --line-length 2000 .`) lives at root `spark-dbt:lint` for now — there is no per-sub-project `lint`/`sqlfluff` here.
 
 ```bash
 # One-time devbox setup
 npx nx run spark-dbt:init --skip-nx-cache --verbose
 
 # Run one project end-to-end (default TARGET=local-local)
+npx nx run dbt-adventureworks:test
+npx nx run dbt-adventureworks:test --TARGET=local-fabric
+
+# Or via the root run target (ad-hoc, bypasses per-sub-project nx caching)
 npx nx run spark-dbt:run --PROJECT=dbt-adventureworks
 npx nx run spark-dbt:run --PROJECT=dbt-adventureworks --TARGET=local-fabric
 
 # Full-refresh (drops & rebuilds incremental + snapshot state)
-FULL_REFRESH=1 npx nx run spark-dbt:run --PROJECT=dbt-dataops
+FULL_REFRESH=1 npx nx run dbt-dataops:test
 
-# Run all 3 sub-projects in parallel
-npx nx run spark-dbt:test
+# Run all 3 sub-projects (CI uses `nx affected -t test`)
+npx nx run-many -t test --projects=dbt-jaffle-shop,dbt-adventureworks,dbt-dataops
+
+# Affected pattern (CI)
+npx nx affected -t test
 
 # ERD + Fabric bundle
 npx nx run spark-dbt:compile

--- a/projects/spark-dbt/README.md
+++ b/projects/spark-dbt/README.md
@@ -58,8 +58,16 @@ Then browse each `dbt-...` project and follow the READMEs:
 # Initiate dbt and Spark
 npx nx run spark-dbt:init --skip-nx-cache --verbose
 
-# Run model
+# Run a single dbt sub-project end-to-end (default TARGET=local-local)
+npx nx run dbt-adventureworks:test
+npx nx run dbt-adventureworks:test --TARGET=local-fabric
+
+# Or via the root run target (ad-hoc)
 npx nx run spark-dbt:run --PROJECT="dbt-adventureworks"
+
+# Run all 3 sub-projects (CI fan-out)
+npx nx run-many -t test --projects=dbt-jaffle-shop,dbt-adventureworks,dbt-dataops
+npx nx affected -t test
 ```
 
 ## 🤖 Using MCP

--- a/projects/spark-dbt/dbt-adventureworks/project.json
+++ b/projects/spark-dbt/dbt-adventureworks/project.json
@@ -1,0 +1,32 @@
+{
+  "name": "dbt-adventureworks",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "targets": {
+    "test": {
+      "executor": "nx:run-commands",
+      "dependsOn": [
+        {
+          "target": "init",
+          "projects": ["spark-dbt"],
+          "params": "ignore"
+        }
+      ],
+      "inputs": [
+        "{projectRoot}/**/*",
+        "{workspaceRoot}/projects/spark-dbt/.scripts/run-dbt-local.sh",
+        "{workspaceRoot}/projects/spark-dbt/pyproject.toml"
+      ],
+      "options": {
+        "cwd": "projects/spark-dbt",
+        "TARGET": "local-local",
+        "commands": [
+          {
+            "command": ".scripts/run-dbt-local.sh dbt-adventureworks {args.TARGET}",
+            "forwardAllArgs": false
+          }
+        ]
+      }
+    }
+  }
+}

--- a/projects/spark-dbt/dbt-dataops/project.json
+++ b/projects/spark-dbt/dbt-dataops/project.json
@@ -1,0 +1,32 @@
+{
+  "name": "dbt-dataops",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "targets": {
+    "test": {
+      "executor": "nx:run-commands",
+      "dependsOn": [
+        {
+          "target": "init",
+          "projects": ["spark-dbt"],
+          "params": "ignore"
+        }
+      ],
+      "inputs": [
+        "{projectRoot}/**/*",
+        "{workspaceRoot}/projects/spark-dbt/.scripts/run-dbt-local.sh",
+        "{workspaceRoot}/projects/spark-dbt/pyproject.toml"
+      ],
+      "options": {
+        "cwd": "projects/spark-dbt",
+        "TARGET": "local-local",
+        "commands": [
+          {
+            "command": ".scripts/run-dbt-local.sh dbt-dataops {args.TARGET}",
+            "forwardAllArgs": false
+          }
+        ]
+      }
+    }
+  }
+}

--- a/projects/spark-dbt/dbt-jaffle-shop/project.json
+++ b/projects/spark-dbt/dbt-jaffle-shop/project.json
@@ -1,0 +1,32 @@
+{
+  "name": "dbt-jaffle-shop",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "targets": {
+    "test": {
+      "executor": "nx:run-commands",
+      "dependsOn": [
+        {
+          "target": "init",
+          "projects": ["spark-dbt"],
+          "params": "ignore"
+        }
+      ],
+      "inputs": [
+        "{projectRoot}/**/*",
+        "{workspaceRoot}/projects/spark-dbt/.scripts/run-dbt-local.sh",
+        "{workspaceRoot}/projects/spark-dbt/pyproject.toml"
+      ],
+      "options": {
+        "cwd": "projects/spark-dbt",
+        "TARGET": "local-local",
+        "commands": [
+          {
+            "command": ".scripts/run-dbt-local.sh dbt-jaffle-shop {args.TARGET}",
+            "forwardAllArgs": false
+          }
+        ]
+      }
+    }
+  }
+}

--- a/projects/spark-dbt/project.json
+++ b/projects/spark-dbt/project.json
@@ -80,19 +80,6 @@
         "cwd": "projects/spark-dbt",
         "commands": [".scripts/compile-erd.sh"]
       }
-    },
-    "test": {
-      "dependsOn": ["init"],
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "projects/spark-dbt",
-        "commands": [
-          "npx nx run spark-dbt:run --PROJECT=dbt-jaffle-shop --TARGET=local-local --verbose --output-style=stream",
-          "npx nx run spark-dbt:run --PROJECT=dbt-adventureworks --TARGET=local-local --verbose --output-style=stream",
-          "npx nx run spark-dbt:run --PROJECT=dbt-dataops --TARGET=local-local --verbose --output-style=stream"
-        ],
-        "parallel": true
-      }
     }
   }
 }


### PR DESCRIPTION
Each `dbt-<name>/` now has its own `project.json` exposing a `test` target, so `npx nx affected -t test` only runs the dbt sub-project whose files actually changed (instead of fan-out across all 3 from the root `spark-dbt` project).

## Scope

- **Move only `test` down.** Root `spark-dbt` keeps `clean`, `install`, `init`, `run`, `package`, `compile`, `lint`.
- **No per-sub-project `lint`/`sqlfluff`** (explicit out-of-scope; can be a follow-up).
- **`dbt-reddit/` excluded** — not a runnable dbt project (no `dbt_project.yml`).

## What changed

- `projects/spark-dbt/dbt-jaffle-shop/project.json` — new (test target only)
- `projects/spark-dbt/dbt-adventureworks/project.json` — new
- `projects/spark-dbt/dbt-dataops/project.json` — new
- `projects/spark-dbt/project.json` — drop `test` target
- Each per-sub-project `test`:
  - `cwd: projects/spark-dbt`
  - `commands: [.scripts/run-dbt-local.sh <name> {args.TARGET}]` (default `TARGET=local-local`)
  - `dependsOn: [{ target: "init", projects: ["spark-dbt"], params: "ignore" }]` — provisions the shared hatch venv + spark-scala metastore once

Mirrors the layout used in `projects/spark-dbt/.temp/monitoring/projects/spark-dbt/`.

## Docs sweep

Removed every stale `npx nx run spark-dbt:test`:

- `projects/spark-dbt/.github/copilot-instructions.md` (§1 layout note, §2 sub-project tree, §4 Nx targets table + bash examples)
- `projects/spark-dbt/README.md` ("Using nx" section)
- `.github/skills/ralph-spark-dbt/skill.md` (Step 3)
- `.github/skills/dbt-to-power-bi/skill.md` (§3f Run)
- `.github/skills/ci-green-runner/skill.md` (change-classification table)

`git grep 'spark-dbt:test'` returns no matches.

## Verification

```bash
# All 3 new projects discovered
$ npx nx show projects | grep dbt
dbt-adventureworks
dbt-dataops
dbt-jaffle-shop
spark-dbt

# DAG correct: each dbt-*:test depends on spark-dbt:init
$ npx nx run-many -t test --projects=dbt-jaffle-shop,dbt-adventureworks,dbt-dataops --graph=…
dbt-adventureworks:test  ->  deps: ['spark-dbt:init']
dbt-dataops:test         ->  deps: ['spark-dbt:init']
dbt-jaffle-shop:test     ->  deps: ['spark-dbt:init']
spark-dbt:init           ->  deps: ['spark-scala:init:dev', 'spark-dbt:install']

# Affected resolution against main
$ npx nx affected --base=origin/main -t test
# fans out into the 3 dbt-*:test tasks + shared init
```

End-to-end Spark/Livy validation is delegated to GCI (running dbt locally requires bringing up the metastore + sbt-built executor jar, which GCI already provisions).
