### PR TITLE
chore(spark-dbt): add per-project sqlfluff lint targets

### DIFF
--- a/projects/spark-dbt/.github/copilot-instructions.md
+++ b/projects/spark-dbt/.github/copilot-instructions.md
@@ -16,17 +16,19 @@ projects/spark-dbt/
 ├── project.json                  # nx root: clean, install, init, run, package, compile, lint
 ├── .scripts/
 │   ├── run-dbt-local.sh          # one-project loop: debug → deps → seed → build → cleanup → docs
+│   ├── lint-dbt.sh               # per-project lint: black (Python) + sqlfluff fix/lint (SQL)
 │   ├── package-fabric.sh         # packages all dbt projects into a Fabric deploy bundle
 │   ├── compile-erd.sh            # ERD compile (dbterd)
 │   └── compile_erd.py
-├── .venv/                        # hatch-managed; dbt + azure-identity + dbterd + dbt-artifacts-parser
+├── .sqlfluff                     # shared sqlfluff config (dbt templater, sparksql, formatting-only)
+├── .venv/                        # hatch-managed; dbt + azure-identity + dbterd + dbt-artifacts-parser + sqlfluff
 │
 ├── dbt-jaffle-shop/              # Jaffle Shop demo (smoke test for the toolchain)
 ├── dbt-adventureworks/           # ★ Canonical Kimball STAR schema demo (dim_* / fct_* / obt_*)
 └── dbt-dataops/                  # Delta Lake KPI STAR schema (dim_* / fct_*, includes snapshots)
 ```
 
-All 3 `dbt-*/` directories are first-class Nx projects with their **own** `project.json` exposing a `test` target, so `nx affected -t test` only runs the sub-project whose files actually changed. The root `spark-dbt` Nx project owns the shared lifecycle (`clean`, `install`, `init`, `run`, `package`, `compile`, `lint`) and the shared hatch venv; `dbt-<name>/project.json::test` declares `dependsOn: [{ target: "init", projects: ["spark-dbt"], params: "ignore" }]` so the venv is provisioned once before the per-sub-project run.
+All `dbt-*/` directories are first-class Nx projects with their **own** `project.json` exposing `test` and `lint` targets, so `nx affected -t test`/`-t lint` only runs the sub-project whose files actually changed. The root `spark-dbt` Nx project owns the shared lifecycle (`clean`, `install`, `init`, `run`, `package`, `compile`) plus a slim root `lint` (black over `.scripts`/`.github`) and the shared hatch venv; `dbt-<name>/project.json::test` and `::lint` declare `dependsOn: [{ target: "init", projects: ["spark-dbt"], params: "ignore" }]` so the venv is provisioned once before the per-sub-project run.
 
 ---
 
@@ -130,12 +132,13 @@ The `spark-dbt` workspace splits responsibilities. The root `spark-dbt` project 
 
 | Nx project           | Owns                                                                 | Targets                                                       |
 | -------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------- |
-| `spark-dbt`          | shared lifecycle (`.scripts/`, `pyproject.toml`, hatch, `lint`)      | `clean`, `install`, `init`, `run`, `package`, `compile`, `lint` |
-| `dbt-jaffle-shop`    | `dbt-jaffle-shop/**`                                                 | `test`                                                        |
-| `dbt-adventureworks` | `dbt-adventureworks/**`                                              | `test`                                                        |
-| `dbt-dataops`        | `dbt-dataops/**`                                                     | `test`                                                        |
+| `spark-dbt`          | shared lifecycle (`.scripts/`, `pyproject.toml`, hatch, `.sqlfluff`) | `clean`, `install`, `init`, `run`, `package`, `compile`, `lint` |
+| `dbt-jaffle-shop`    | `dbt-jaffle-shop/**`                                                 | `test`, `lint`                                               |
+| `dbt-adventureworks` | `dbt-adventureworks/**`                                              | `test`, `lint`                                               |
+| `dbt-dataops`        | `dbt-dataops/**`                                                     | `test`, `lint`                                               |
+| `dbt-reddit`         | `dbt-reddit/**`                                                      | `test`, `lint`                                               |
 
-Each per-sub-project `test` invokes `.scripts/run-dbt-local.sh <project> {args.TARGET}` (default `TARGET=local-local`) and depends on `spark-dbt:init` (`params: "ignore"`) so the shared hatch venv is set up first. Lint (`black --line-length 2000 .`) lives at root `spark-dbt:lint` for now — there is no per-sub-project `lint`/`sqlfluff` here.
+Each per-sub-project `test` invokes `.scripts/run-dbt-local.sh <project> {args.TARGET}` (default `TARGET=local-local`) and `lint` invokes `.scripts/lint-dbt.sh <project>`; both depend on `spark-dbt:init` (`params: "ignore"`) so the shared hatch venv is set up first. The root `spark-dbt:lint` is a slim `black --line-length 2000 .scripts .github` for the shared Python not owned by any dbt sub-project; the per-project `lint` adds `sqlfluff` (see §7).
 
 ```bash
 # One-time devbox setup
@@ -204,16 +207,27 @@ Use the `using-dbt-for-analytics-engineering` skill ([`skills/using-dbt-for-anal
 
 ## 7. Linting
 
-Lint at this scope is **Python-only** via `black` (intentionally wide at `--line-length 2000` for `compile_erd.py`-style configs). SQL is **not** linted — but `dbt parse` must succeed:
+Two layers, both picked up by `nx affected -t lint`:
+
+- **Per-dbt-project (SQL + Python)** — `dbt-<name>:lint` runs `.scripts/lint-dbt.sh <project>`: `black --line-length 2000 <project>` then `sqlfluff fix` + `sqlfluff lint` over the project's `models`/`snapshots` (snapshots only if present). sqlfluff uses the shared `projects/spark-dbt/.sqlfluff` (dbt templater, `dialect=sparksql`, `target=lint`). The rule set is an **allowlist of `capitalisation` + `layout`** — i.e. formatting-only (casing, whitespace, indentation). Structural rewrites (CASE→COALESCE, alias/column-list removal, join-condition reordering, reference re-qualification) are intentionally **off** so lint never changes query semantics.
+- **Root shared Python** — `spark-dbt:lint` is a slim `black --line-length 2000 .scripts .github` for the root scripts/skills not owned by any sub-project.
 
 ```bash
-# Repo-root: lint all Python under projects/spark-dbt/
+# Lint one dbt project (black + sqlfluff fix/lint)
+npx nx run dbt-adventureworks:lint
+
+# Lint root shared Python
 npx nx run spark-dbt:lint
 
-# Local: validate Jinja+SQL parses cleanly before pushing
-cd projects/spark-dbt && hatch shell
-cd dbt-adventureworks && DBT_PROFILES_DIR=$(pwd) dbt parse
+# All affected (CI pattern)
+npx nx affected -t lint
 ```
+
+Notes:
+
+- The `lint` output in each `dbt-<name>/profiles.yml` is a static Livy-local target (`connect_retries: 0`, short timeouts) so sqlfluff's dbt templater compiles **without** a live Spark session.
+- Introspective models that need a live relation at compile time (e.g. `obt_sales.sql` via `dbt_utils.star`) can't be templated statically; sqlfluff skips them with a warning under `--ignore templating,parsing` (not a lint failure).
+- `dbt parse` must still succeed: `cd dbt-adventureworks && DBT_PROFILES_DIR=$(pwd) dbt parse`.
 
 ---
 
@@ -251,6 +265,7 @@ Update the ERD whenever you add / remove / rename a `dim_*` or `fct_*`, or chang
 - [ ] CTEs preferred over subqueries; staging predicates pushed to `stg_*`.
 - [ ] ERD regenerated (`npx nx run spark-dbt:compile`) if the DAG changed.
 - [ ] `dbt parse` succeeds against `local-local`.
+- [ ] `npx nx run dbt-<name>:lint` is clean (`sqlfluff` formatting + `black`) before opening a PR.
 - [ ] `dbt build --select <model>+` succeeds against `local-local` before opening a PR.
 - [ ] Unit tests added for any model with non-trivial logic — see [`skills/adding-dbt-unit-test/skill.md`](skills/adding-dbt-unit-test/skill.md).
 

--- a/projects/spark-dbt/.github/copilot-instructions.md
+++ b/projects/spark-dbt/.github/copilot-instructions.md
@@ -226,7 +226,7 @@ npx nx affected -t lint
 Notes:
 
 - The `lint` output in each `dbt-<name>/profiles.yml` is a static Livy-local target (`connect_retries: 0`, short timeouts) so sqlfluff's dbt templater compiles **without** a live Spark session.
-- Introspective models that need a live relation at compile time (e.g. `obt_sales.sql` via `dbt_utils.star`) can't be templated statically; sqlfluff skips them with a warning under `--ignore templating,parsing` (not a lint failure).
+- Introspective models that need a live relation at compile time (e.g. `obt_*.sql` via `dbt_utils.star`) compile non-deterministically (only when the upstream tables already exist), so they are excluded from sqlfluff via a `.sqlfluffignore` in the owning project (e.g. `dbt-adventureworks/.sqlfluffignore`). Add any new introspective model to that ignore file.
 - `dbt parse` must still succeed: `cd dbt-adventureworks && DBT_PROFILES_DIR=$(pwd) dbt parse`.
 
 ---

--- a/projects/spark-dbt/.scripts/lint-dbt.sh
+++ b/projects/spark-dbt/.scripts/lint-dbt.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+#
+#       Script to lint a single dbt project: black (Python) + sqlfluff (SQL).
+#
+#       Mirrors run-dbt-local.sh: activates the shared hatch venv, cd's into the
+#       project, points DBT_PROFILES_DIR at it, then runs sqlfluff with the dbt
+#       templater (sparksql) against the dirs that exist among models/snapshots.
+#
+#       Usage: lint-dbt.sh <dbt-project>
+#       Example: lint-dbt.sh dbt-dataops
+#
+# ---------------------------------------------------------------------------------------
+#
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <dbt-project>"
+    echo "Example: $0 dbt-dataops"
+    exit 1
+fi
+
+DBT_PROJECT="$1"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}/.."
+source .venv/bin/activate
+
+if [[ ! -d "${DBT_PROJECT}" ]]; then
+    echo "Error: dbt project directory '${DBT_PROJECT}' not found under $(pwd)" >&2
+    exit 1
+fi
+
+export GIT_ROOT=$(git rev-parse --show-toplevel)
+
+echo "Linting Python (black) for '${DBT_PROJECT}'"
+black --line-length 2000 "${DBT_PROJECT}"
+
+cd "${DBT_PROJECT}"
+export DBT_PROFILES_DIR=$(pwd)
+
+dbt deps
+
+LINT_DIRS=()
+for d in models snapshots; do
+    if [[ -d "${d}" ]]; then
+        LINT_DIRS+=("${d}")
+    fi
+done
+
+if [[ ${#LINT_DIRS[@]} -eq 0 ]]; then
+    echo "No lintable directories (models/snapshots) found in '${DBT_PROJECT}'; skipping sqlfluff."
+    exit 0
+fi
+
+echo "Linting SQL (sqlfluff) for '${DBT_PROJECT}': ${LINT_DIRS[*]}"
+sqlfluff fix "${LINT_DIRS[@]}" --dialect sparksql --ignore templating,parsing
+sqlfluff lint "${LINT_DIRS[@]}" --dialect sparksql --ignore templating,parsing

--- a/projects/spark-dbt/.sqlfluff
+++ b/projects/spark-dbt/.sqlfluff
@@ -1,0 +1,29 @@
+[sqlfluff]
+templater = dbt
+dialect = sparksql
+# Allowlist formatting-only rule groups so lint never rewrites query structure
+# (no CASE->COALESCE, no alias/column-list removal, no join-condition reordering,
+#  no reference re-qualification). Keeps casing + whitespace/layout cleanup only.
+rules = capitalisation, layout
+exclude_rules = LT05, LT09, LT14
+max_line_length = 120
+ignore = templating, parsing
+
+[sqlfluff:templater:dbt]
+target = lint
+
+[sqlfluff:indentation]
+indent_unit = space
+tab_space_size = 4
+
+[sqlfluff:rules:capitalisation.keywords]
+capitalisation_policy = upper
+
+[sqlfluff:rules:capitalisation.functions]
+capitalisation_policy = upper
+
+[sqlfluff:rules:capitalisation.literals]
+capitalisation_policy = upper
+
+[sqlfluff:rules:capitalisation.identifiers]
+capitalisation_policy = lower

--- a/projects/spark-dbt/dbt-adventureworks/.sqlfluffignore
+++ b/projects/spark-dbt/dbt-adventureworks/.sqlfluffignore
@@ -1,0 +1,5 @@
+# One-big-table (obt_*) models use dbt_utils.star, which introspects live
+# relations at compile time. They can only be templated when the upstream
+# tables already exist + a Spark session is up, so sqlfluff's result is
+# non-deterministic (skipped vs fixed). Exclude them so lint is deterministic.
+obt_*.sql

--- a/projects/spark-dbt/dbt-adventureworks/models/marts/dim_address.sql
+++ b/projects/spark-dbt/dbt-adventureworks/models/marts/dim_address.sql
@@ -1,24 +1,24 @@
-with stg_address as (
-    select *
-    from {{ ref('address') }}
+WITH stg_address AS (
+    SELECT *
+    FROM {{ ref('address') }}
 ),
 
-stg_stateprovince as (
-    select *
-    from {{ ref('stateprovince') }}
+stg_stateprovince AS (
+    SELECT *
+    FROM {{ ref('stateprovince') }}
 ),
 
-stg_countryregion as (
-    select *
-    from {{ ref('countryregion') }}
+stg_countryregion AS (
+    SELECT *
+    FROM {{ ref('countryregion') }}
 )
 
-select
-    {{ dbt_utils.generate_surrogate_key(['stg_address.addressid']) }} as address_key,
+SELECT
+    {{ dbt_utils.generate_surrogate_key(['stg_address.addressid']) }} AS address_key,
     stg_address.addressid,
-    stg_address.city as city_name,
-    stg_stateprovince.name as state_name,
-    stg_countryregion.name as country_name
-from stg_address
-left join stg_stateprovince on stg_address.stateprovinceid = stg_stateprovince.stateprovinceid
-left join stg_countryregion on stg_stateprovince.countryregioncode = stg_countryregion.countryregioncode
+    stg_address.city AS city_name,
+    stg_stateprovince.name AS state_name,
+    stg_countryregion.name AS country_name
+FROM stg_address
+LEFT JOIN stg_stateprovince ON stg_address.stateprovinceid = stg_stateprovince.stateprovinceid
+LEFT JOIN stg_countryregion ON stg_stateprovince.countryregioncode = stg_countryregion.countryregioncode

--- a/projects/spark-dbt/dbt-adventureworks/models/marts/dim_credit_card.sql
+++ b/projects/spark-dbt/dbt-adventureworks/models/marts/dim_credit_card.sql
@@ -1,17 +1,17 @@
-with stg_salesorderheader as (
-    select distinct creditcardid
-    from {{ ref('salesorderheader') }}
-    where creditcardid is not null
+WITH stg_salesorderheader AS (
+    SELECT DISTINCT creditcardid
+    FROM {{ ref('salesorderheader') }}
+    WHERE creditcardid IS NOT NULL
 ),
 
-stg_creditcard as (
-    select *
-    from {{ ref('creditcard') }}
+stg_creditcard AS (
+    SELECT *
+    FROM {{ ref('creditcard') }}
 )
 
-select
-    {{ dbt_utils.generate_surrogate_key(['stg_salesorderheader.creditcardid']) }} as creditcard_key,
+SELECT
+    {{ dbt_utils.generate_surrogate_key(['stg_salesorderheader.creditcardid']) }} AS creditcard_key,
     stg_salesorderheader.creditcardid,
     stg_creditcard.cardtype
-from stg_salesorderheader
-left join stg_creditcard on stg_salesorderheader.creditcardid = stg_creditcard.creditcardid
+FROM stg_salesorderheader
+LEFT JOIN stg_creditcard ON stg_salesorderheader.creditcardid = stg_creditcard.creditcardid

--- a/projects/spark-dbt/dbt-adventureworks/models/marts/dim_customer.sql
+++ b/projects/spark-dbt/dbt-adventureworks/models/marts/dim_customer.sql
@@ -1,32 +1,32 @@
-with stg_customer as (
-    select
+WITH stg_customer AS (
+    SELECT
         customerid,
         personid,
         storeid
-    from {{ ref('customer') }}
+    FROM {{ ref('customer') }}
 ),
 
-stg_person as (
-    select
+stg_person AS (
+    SELECT
         businessentityid,
-        concat(coalesce(firstname, ''), ' ', coalesce(middlename, ''), ' ', coalesce(lastname, '')) as fullname
-    from {{ ref('person') }}
+        concat(coalesce(firstname, ''), ' ', coalesce(middlename, ''), ' ', coalesce(lastname, '')) AS fullname
+    FROM {{ ref('person') }}
 ),
 
-stg_store as (
-    select
-        businessentityid as storebusinessentityid,
+stg_store AS (
+    SELECT
+        businessentityid AS storebusinessentityid,
         storename
-    from {{ ref('store') }}
+    FROM {{ ref('store') }}
 )
 
-select
-    {{ dbt_utils.generate_surrogate_key(['stg_customer.customerid']) }} as customer_key,
+SELECT
+    {{ dbt_utils.generate_surrogate_key(['stg_customer.customerid']) }} AS customer_key,
     stg_customer.customerid,
     stg_person.businessentityid,
     stg_person.fullname,
     stg_store.storebusinessentityid,
     stg_store.storename
-from stg_customer
-left join stg_person on stg_customer.personid = stg_person.businessentityid
-left join stg_store on stg_customer.storeid = stg_store.storebusinessentityid
+FROM stg_customer
+LEFT JOIN stg_person ON stg_customer.personid = stg_person.businessentityid
+LEFT JOIN stg_store ON stg_customer.storeid = stg_store.storebusinessentityid

--- a/projects/spark-dbt/dbt-adventureworks/models/marts/dim_date.sql
+++ b/projects/spark-dbt/dbt-adventureworks/models/marts/dim_date.sql
@@ -1,8 +1,8 @@
-with stg_date as (
-    select * from {{ ref('date') }}
+WITH stg_date AS (
+    SELECT * FROM {{ ref('date') }}
 )
 
-select
-    {{ dbt_utils.generate_surrogate_key(['stg_date.date_day']) }} as date_key,
+SELECT
+    {{ dbt_utils.generate_surrogate_key(['stg_date.date_day']) }} AS date_key,
     *
-from stg_date
+FROM stg_date

--- a/projects/spark-dbt/dbt-adventureworks/models/marts/dim_order_status.sql
+++ b/projects/spark-dbt/dbt-adventureworks/models/marts/dim_order_status.sql
@@ -1,19 +1,19 @@
-with stg_order_status as (
-    select distinct status as order_status
-    from
+WITH stg_order_status AS (
+    SELECT DISTINCT status AS order_status
+    FROM
         {{ ref('salesorderheader') }}
 )
 
-select
-    {{ dbt_utils.generate_surrogate_key(['stg_order_status.order_status']) }} as order_status_key,
+SELECT
+    {{ dbt_utils.generate_surrogate_key(['stg_order_status.order_status']) }} AS order_status_key,
     order_status,
-    case
-        when order_status = 1 then 'in_process'
-        when order_status = 2 then 'approved'
-        when order_status = 3 then 'backordered'
-        when order_status = 4 then 'rejected'
-        when order_status = 5 then 'shipped'
-        when order_status = 6 then 'cancelled'
-        else 'no_status'
-    end as order_status_name
-from stg_order_status
+    CASE
+        WHEN order_status = 1 THEN 'in_process'
+        WHEN order_status = 2 THEN 'approved'
+        WHEN order_status = 3 THEN 'backordered'
+        WHEN order_status = 4 THEN 'rejected'
+        WHEN order_status = 5 THEN 'shipped'
+        WHEN order_status = 6 THEN 'cancelled'
+        ELSE 'no_status'
+    END AS order_status_name
+FROM stg_order_status

--- a/projects/spark-dbt/dbt-adventureworks/models/marts/dim_product.sql
+++ b/projects/spark-dbt/dbt-adventureworks/models/marts/dim_product.sql
@@ -1,27 +1,27 @@
-with stg_product as (
-    select *
-    from {{ ref('product') }}
+WITH stg_product AS (
+    SELECT *
+    FROM {{ ref('product') }}
 ),
 
-stg_product_subcategory as (
-    select *
-    from {{ ref('productsubcategory') }}
+stg_product_subcategory AS (
+    SELECT *
+    FROM {{ ref('productsubcategory') }}
 ),
 
-stg_product_category as (
-    select *
-    from {{ ref('productcategory') }}
+stg_product_category AS (
+    SELECT *
+    FROM {{ ref('productcategory') }}
 )
 
-select
-    {{ dbt_utils.generate_surrogate_key(['stg_product.productid']) }} as product_key,
+SELECT
+    {{ dbt_utils.generate_surrogate_key(['stg_product.productid']) }} AS product_key,
     stg_product.productid,
-    stg_product.name as product_name,
+    stg_product.name AS product_name,
     stg_product.productnumber,
     stg_product.color,
     stg_product.class,
-    stg_product_subcategory.name as product_subcategory_name,
-    stg_product_category.name as product_category_name
-from stg_product
-left join stg_product_subcategory on stg_product.productsubcategoryid = stg_product_subcategory.productsubcategoryid
-left join stg_product_category on stg_product_subcategory.productcategoryid = stg_product_category.productcategoryid
+    stg_product_subcategory.name AS product_subcategory_name,
+    stg_product_category.name AS product_category_name
+FROM stg_product
+LEFT JOIN stg_product_subcategory ON stg_product.productsubcategoryid = stg_product_subcategory.productsubcategoryid
+LEFT JOIN stg_product_category ON stg_product_subcategory.productcategoryid = stg_product_category.productcategoryid

--- a/projects/spark-dbt/dbt-adventureworks/models/marts/fct_sales.sql
+++ b/projects/spark-dbt/dbt-adventureworks/models/marts/fct_sales.sql
@@ -1,44 +1,45 @@
-with stg_salesorderheader as (
-    select
+WITH stg_salesorderheader AS (
+    SELECT
         salesorderid,
         customerid,
         creditcardid,
         shiptoaddressid,
-        status as order_status,
-        cast(orderdate as date) as orderdate
-    from {{ ref('salesorderheader') }}
+        status AS order_status,
+        cast(orderdate AS date) AS orderdate
+    FROM {{ ref('salesorderheader') }}
 ),
 
-stg_salesorderdetail as (
-    select
+stg_salesorderdetail AS (
+    SELECT
         salesorderid,
         salesorderdetailid,
         productid,
         orderqty,
         unitprice,
-        unitprice * orderqty as revenue
-    from {{ ref('salesorderdetail') }}
+        unitprice * orderqty AS revenue
+    FROM {{ ref('salesorderdetail') }}
 )
 
-select
-    {{ dbt_utils.generate_surrogate_key(['stg_salesorderdetail.salesorderid', 'salesorderdetailid']) }} as sales_key,
-    {{ dbt_utils.generate_surrogate_key(['productid']) }} as product_key,
-    {{ dbt_utils.generate_surrogate_key(['customerid']) }} as customer_key,
-    case when creditcardid is not null
-        then {{ dbt_utils.generate_surrogate_key(['creditcardid']) }}
-        else null
-    end as creditcard_key,
-    {{ dbt_utils.generate_surrogate_key(['shiptoaddressid']) }} as ship_address_key,
-    {{ dbt_utils.generate_surrogate_key(['order_status']) }} as order_status_key,
-    {{ dbt_utils.generate_surrogate_key(['orderdate']) }} as order_date_key,
+SELECT
+    {{ dbt_utils.generate_surrogate_key(['stg_salesorderdetail.salesorderid', 'salesorderdetailid']) }} AS sales_key,
+    {{ dbt_utils.generate_surrogate_key(['productid']) }} AS product_key,
+    {{ dbt_utils.generate_surrogate_key(['customerid']) }} AS customer_key,
+    CASE
+        WHEN creditcardid IS NOT NULL
+            THEN {{ dbt_utils.generate_surrogate_key(['creditcardid']) }}
+        ELSE NULL
+    END AS creditcard_key,
+    {{ dbt_utils.generate_surrogate_key(['shiptoaddressid']) }} AS ship_address_key,
+    {{ dbt_utils.generate_surrogate_key(['order_status']) }} AS order_status_key,
+    {{ dbt_utils.generate_surrogate_key(['orderdate']) }} AS order_date_key,
     stg_salesorderdetail.salesorderid,
     stg_salesorderdetail.salesorderdetailid,
     stg_salesorderdetail.unitprice,
     stg_salesorderdetail.orderqty,
     stg_salesorderdetail.revenue
-from stg_salesorderdetail
-inner join stg_salesorderheader on stg_salesorderdetail.salesorderid = stg_salesorderheader.salesorderid
-where exists (
-    select 1 from {{ ref('dim_address') }} da
-    where da.address_key = {{ dbt_utils.generate_surrogate_key(['stg_salesorderheader.shiptoaddressid']) }}
+FROM stg_salesorderdetail
+INNER JOIN stg_salesorderheader ON stg_salesorderdetail.salesorderid = stg_salesorderheader.salesorderid
+WHERE EXISTS (
+    SELECT 1 FROM {{ ref('dim_address') }} da
+    WHERE da.address_key = {{ dbt_utils.generate_surrogate_key(['stg_salesorderheader.shiptoaddressid']) }}
 )

--- a/projects/spark-dbt/dbt-adventureworks/profiles.yml
+++ b/projects/spark-dbt/dbt-adventureworks/profiles.yml
@@ -1,6 +1,22 @@
 adventureworks:
   target: local-local
   outputs:
+    # Lint-only static target (sqlfluff dbt templater) - no live Spark session
+    lint:
+      authentication: cli
+      method: livy
+      livy_mode: local
+      connect_retries: 0
+      retry_all: false
+      http_timeout: 5
+      statement_timeout: 5
+      lakehouse: dbt_adventureworks_dwh
+      schema: dbt_adventureworks_dwh
+      threads: 4
+      type: fabricspark
+      spark_config:
+        name: dbt-adventureworks
+
     # Local dbt client + Local spark server (default for development)
     local-local:
       authentication: cli

--- a/projects/spark-dbt/dbt-adventureworks/project.json
+++ b/projects/spark-dbt/dbt-adventureworks/project.json
@@ -27,6 +27,21 @@
           }
         ]
       }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "cache": false,
+      "inputs": [
+        "{projectRoot}/**/*",
+        "{workspaceRoot}/projects/spark-dbt/.scripts/lint-dbt.sh",
+        "{workspaceRoot}/projects/spark-dbt/.sqlfluff",
+        "{workspaceRoot}/projects/spark-dbt/pyproject.toml"
+      ],
+      "options": {
+        "cwd": "projects/spark-dbt",
+        "commands": [".scripts/lint-dbt.sh dbt-adventureworks"],
+        "parallel": false
+      }
     }
   }
 }

--- a/projects/spark-dbt/dbt-dataops/models/marts/dim_date.sql
+++ b/projects/spark-dbt/dbt-dataops/models/marts/dim_date.sql
@@ -6,27 +6,27 @@
     )
 }}
 
-with date_spine as (
-    select
+WITH date_spine AS (
+    SELECT
         explode(
             sequence(
-                cast('2024-01-01' as date),
-                cast('2027-12-31' as date),
-                interval 1 day
+                cast('2024-01-01' AS date),
+                cast('2027-12-31' AS date),
+                INTERVAL 1 DAY
             )
-        ) as full_date
+        ) AS full_date
 )
 
-select
-    date_format(full_date, 'yyyyMMdd') as date_key,
+SELECT
+    date_format(full_date, 'yyyyMMdd') AS date_key,
     full_date,
-    year(full_date) as year,
-    quarter(full_date) as quarter,
-    month(full_date) as month,
-    date_format(full_date, 'MMMM') as month_name,
-    day(full_date) as day_of_month,
-    dayofweek(full_date) as day_of_week,
-    date_format(full_date, 'EEEE') as day_name,
-    weekofyear(full_date) as week_of_year,
-    case when dayofweek(full_date) in (1, 7) then true else false end as is_weekend
-from date_spine
+    year(full_date) AS year,
+    quarter(full_date) AS quarter,
+    month(full_date) AS month,
+    date_format(full_date, 'MMMM') AS month_name,
+    day(full_date) AS day_of_month,
+    dayofweek(full_date) AS day_of_week,
+    date_format(full_date, 'EEEE') AS day_name,
+    weekofyear(full_date) AS week_of_year,
+    CASE WHEN dayofweek(full_date) IN (1, 7) THEN TRUE ELSE FALSE END AS is_weekend
+FROM date_spine

--- a/projects/spark-dbt/dbt-dataops/models/marts/dim_delta_table.sql
+++ b/projects/spark-dbt/dbt-dataops/models/marts/dim_delta_table.sql
@@ -6,19 +6,20 @@
     )
 }}
 
-with snapshot_data as (
-    select * from {{ ref('snap_dim_delta_table') }}
+WITH snapshot_data AS (
+    SELECT * FROM {{ ref('snap_dim_delta_table') }}
 ),
 
 -- Propagate latest SCD1 column values across all historical versions
 -- This implements Type 1 behavior: the latest value overwrites all versions
-with_scd1_propagation as (
-    select
+with_scd1_propagation AS (
+    SELECT
         -- Surrogate key: unique per SCD2 version
-        sha2(concat_ws('|',
+        sha2(concat_ws(
+            '|',
             table_fqn,
-            cast(dbt_valid_from as string)
-        ), 256) as __pk,
+            cast(dbt_valid_from AS string)
+        ), 256) AS __pk,
 
         -- Business key
         table_fqn,
@@ -26,26 +27,26 @@ with_scd1_propagation as (
         table_name,
 
         -- SCD1 columns: propagate latest value across all versions
-        last_value(table_id) over (
-            partition by table_fqn
-            order by dbt_valid_from
-            rows between unbounded preceding and unbounded following
-        ) as table_id,
-        last_value(location) over (
-            partition by table_fqn
-            order by dbt_valid_from
-            rows between unbounded preceding and unbounded following
-        ) as location,
-        last_value(format) over (
-            partition by table_fqn
-            order by dbt_valid_from
-            rows between unbounded preceding and unbounded following
-        ) as format,
-        last_value(partition_columns) over (
-            partition by table_fqn
-            order by dbt_valid_from
-            rows between unbounded preceding and unbounded following
-        ) as partition_columns,
+        last_value(table_id) OVER (
+            PARTITION BY table_fqn
+            ORDER BY dbt_valid_from
+            ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS table_id,
+        last_value(location) OVER (
+            PARTITION BY table_fqn
+            ORDER BY dbt_valid_from
+            ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS location,
+        last_value(format) OVER (
+            PARTITION BY table_fqn
+            ORDER BY dbt_valid_from
+            ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS format,
+        last_value(partition_columns) OVER (
+            PARTITION BY table_fqn
+            ORDER BY dbt_valid_from
+            ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS partition_columns,
 
         -- SCD2 columns: version-specific (historical values preserved)
         clustering_columns,
@@ -59,13 +60,13 @@ with_scd1_propagation as (
         __merge_effective_date,
 
         -- SCD2 tracking columns
-        dbt_valid_from as row_effective_start,
-        dbt_valid_to as row_effective_end,
-        case when dbt_valid_to is null then true else false end as is_row_effective,
-        dbt_scd_id as __scd_id,
-        dbt_updated_at as __merge_ingest_time
+        dbt_valid_from AS row_effective_start,
+        dbt_valid_to AS row_effective_end,
+        CASE WHEN dbt_valid_to IS NULL THEN TRUE ELSE FALSE END AS is_row_effective,
+        dbt_scd_id AS __scd_id,
+        dbt_updated_at AS __merge_ingest_time
 
-    from snapshot_data
+    FROM snapshot_data
 )
 
-select * from with_scd1_propagation
+SELECT * FROM with_scd1_propagation

--- a/projects/spark-dbt/dbt-dataops/models/marts/dim_delta_table_health_status.sql
+++ b/projects/spark-dbt/dbt-dataops/models/marts/dim_delta_table_health_status.sql
@@ -6,14 +6,14 @@
     )
 }}
 
-select
-    sha2(status, 256) as health_status_key,
+SELECT
+    sha2(status, 256) AS health_status_key,
     status,
     description,
     severity_rank
-from (
-    values
-        ('Healthy', 'All monitored metrics are within expected bounds.', 1),
-        ('Training', 'Insufficient historical data to determine health status. Minimum thresholds not yet met.', 2),
-        ('Unhealthy', 'One or more monitored metrics are outside expected bounds, indicating potential data quality issues.', 3)
-) as t(status, description, severity_rank)
+FROM (
+    VALUES
+    ('Healthy', 'All monitored metrics are within expected bounds.', 1),
+    ('Training', 'Insufficient historical data to determine health status. Minimum thresholds not yet met.', 2),
+    ('Unhealthy', 'One or more monitored metrics are outside expected bounds, indicating potential data quality issues.', 3)
+) AS t (status, description, severity_rank)

--- a/projects/spark-dbt/dbt-dataops/models/marts/dim_delta_table_operation_type.sql
+++ b/projects/spark-dbt/dbt-dataops/models/marts/dim_delta_table_operation_type.sql
@@ -6,38 +6,38 @@
     )
 }}
 
-with operations as (
-    select
+WITH operations AS (
+    SELECT
         operation,
         operation_category,
-        cast(is_data_changing as boolean) as is_data_changing,
-        cast(is_row_producing as boolean) as is_row_producing,
+        cast(is_data_changing AS boolean) AS is_data_changing,
+        cast(is_row_producing AS boolean) AS is_row_producing,
         description
-    from (
-        values
-            ('WRITE', 'data_changing', true, true, 'Inserts or overwrites data in a table'),
-            ('MERGE', 'data_changing', true, true, 'Upserts data using merge conditions'),
-            ('UPDATE', 'data_changing', true, false, 'Updates existing rows in place'),
-            ('DELETE', 'data_changing', true, false, 'Deletes rows from a table'),
-            ('STREAMING UPDATE', 'data_changing', true, true, 'Streaming micro-batch write operation'),
-            ('INSERT', 'data_changing', true, true, 'Inserts new rows into a table'),
-            ('CREATE TABLE AS SELECT', 'ddl', true, true, 'Creates a new table from a query result'),
-            ('REPLACE TABLE AS SELECT', 'ddl', true, true, 'Replaces table contents from a query result'),
-            ('CREATE OR REPLACE TABLE AS SELECT', 'ddl', true, true, 'Creates or replaces table from a query result'),
-            ('CREATE OR REPLACE TABLE', 'ddl', true, false, 'Creates or replaces a table definition'),
-            ('OPTIMIZE', 'maintenance', false, false, 'Compacts small files into larger files'),
-            ('VACUUM', 'maintenance', false, false, 'Removes old files no longer referenced'),
-            ('RESTORE', 'maintenance', false, false, 'Restores table to a previous version'),
-            ('SET TBLPROPERTIES', 'maintenance', false, false, 'Modifies table properties'),
-            ('CONVERT', 'ddl', true, false, 'Converts Parquet table to Delta format')
-    ) as t(operation, operation_category, is_data_changing, is_row_producing, description)
+    FROM (
+        VALUES
+        ('WRITE', 'data_changing', TRUE, TRUE, 'Inserts or overwrites data in a table'),
+        ('MERGE', 'data_changing', TRUE, TRUE, 'Upserts data using merge conditions'),
+        ('UPDATE', 'data_changing', TRUE, FALSE, 'Updates existing rows in place'),
+        ('DELETE', 'data_changing', TRUE, FALSE, 'Deletes rows from a table'),
+        ('STREAMING UPDATE', 'data_changing', TRUE, TRUE, 'Streaming micro-batch write operation'),
+        ('INSERT', 'data_changing', TRUE, TRUE, 'Inserts new rows into a table'),
+        ('CREATE TABLE AS SELECT', 'ddl', TRUE, TRUE, 'Creates a new table from a query result'),
+        ('REPLACE TABLE AS SELECT', 'ddl', TRUE, TRUE, 'Replaces table contents from a query result'),
+        ('CREATE OR REPLACE TABLE AS SELECT', 'ddl', TRUE, TRUE, 'Creates or replaces table from a query result'),
+        ('CREATE OR REPLACE TABLE', 'ddl', TRUE, FALSE, 'Creates or replaces a table definition'),
+        ('OPTIMIZE', 'maintenance', FALSE, FALSE, 'Compacts small files into larger files'),
+        ('VACUUM', 'maintenance', FALSE, FALSE, 'Removes old files no longer referenced'),
+        ('RESTORE', 'maintenance', FALSE, FALSE, 'Restores table to a previous version'),
+        ('SET TBLPROPERTIES', 'maintenance', FALSE, FALSE, 'Modifies table properties'),
+        ('CONVERT', 'ddl', TRUE, FALSE, 'Converts Parquet table to Delta format')
+    ) AS t (operation, operation_category, is_data_changing, is_row_producing, description)
 )
 
-select
-    sha2(operation, 256) as operation_type_key,
+SELECT
+    sha2(operation, 256) AS operation_type_key,
     operation,
     operation_category,
     is_data_changing,
     is_row_producing,
     description
-from operations
+FROM operations

--- a/projects/spark-dbt/dbt-dataops/models/marts/fct_delta_commit.sql
+++ b/projects/spark-dbt/dbt-dataops/models/marts/fct_delta_commit.sql
@@ -9,14 +9,14 @@
     )
 }}
 
-with src as (
-    select
+WITH src AS (
+    SELECT
         *,
-        row_number() over (
-            partition by table_fqn, version
-            order by ingested_at desc
-        ) as _row_num
-    from {{ ref('stg_delta_commit_history') }}
+        row_number() OVER (
+            PARTITION BY table_fqn, version
+            ORDER BY ingested_at DESC
+        ) AS _row_num
+    FROM {{ ref('stg_delta_commit_history') }}
     {% if is_incremental() %}
     where
         snapshot_date >= (select date_format(max(commit_timestamp), 'yyyyMMdd') from {{ this }})
@@ -24,23 +24,23 @@ with src as (
     {% endif %}
 ),
 
-deduped as (
-    select * from src where _row_num = 1
+deduped AS (
+    SELECT * FROM src WHERE _row_num = 1
 ),
 
-dim_tbl as (
-    select __pk as table_key, table_fqn, row_effective_start, row_effective_end
-    from {{ ref('dim_delta_table') }}
+dim_tbl AS (
+    SELECT __pk AS table_key, table_fqn, row_effective_start, row_effective_end
+    FROM {{ ref('dim_delta_table') }}
 ),
 
-dim_op as (
-    select operation_type_key, operation
-    from {{ ref('dim_delta_table_operation_type') }}
+dim_op AS (
+    SELECT operation_type_key, operation
+    FROM {{ ref('dim_delta_table_operation_type') }}
 ),
 
-fact as (
-    select
-        sha2(concat_ws('|', deduped.table_fqn, cast(deduped.version as string)), 256) as commit_key,
+fact AS (
+    SELECT
+        sha2(concat_ws('|', deduped.table_fqn, cast(deduped.version AS string)), 256) AS commit_key,
         dim_tbl.table_key,
         dim_op.operation_type_key,
         deduped.date_key,
@@ -53,16 +53,17 @@ fact as (
         deduped.execution_time_ms,
         deduped.is_blind_append,
         deduped.ingested_at,
-        current_timestamp() as dbt_loaded_at,
-        date_format(current_timestamp(), 'yyyyMMdd') as event_year_date
+        current_timestamp() AS dbt_loaded_at,
+        date_format(current_timestamp(), 'yyyyMMdd') AS event_year_date
 
-    from deduped
-    inner join dim_tbl
-        on deduped.table_fqn = dim_tbl.table_fqn
-        and deduped.commit_timestamp >= dim_tbl.row_effective_start
-        and deduped.commit_timestamp < coalesce(dim_tbl.row_effective_end, cast('9999-12-31' as timestamp))
-    left join dim_op on deduped.operation = dim_op.operation
+    FROM deduped
+    INNER JOIN dim_tbl
+        ON
+            deduped.table_fqn = dim_tbl.table_fqn
+            AND deduped.commit_timestamp >= dim_tbl.row_effective_start
+            AND deduped.commit_timestamp < coalesce(dim_tbl.row_effective_end, cast('9999-12-31' AS timestamp))
+    LEFT JOIN dim_op ON deduped.operation = dim_op.operation
 )
 
-select * from fact
+SELECT * FROM fact
 {{ fact_not_exists('commit_key', 'fact') }}

--- a/projects/spark-dbt/dbt-dataops/models/marts/fct_delta_health.sql
+++ b/projects/spark-dbt/dbt-dataops/models/marts/fct_delta_health.sql
@@ -9,14 +9,14 @@
     )
 }}
 
-with src as (
-    select
+WITH src AS (
+    SELECT
         *,
-        row_number() over (
-            partition by table_fqn, snapshot_date, evaluation_timestamp
-            order by evaluation_timestamp desc
-        ) as _row_num
-    from {{ ref('stg_delta_kpi_results') }}
+        row_number() OVER (
+            PARTITION BY table_fqn, snapshot_date, evaluation_timestamp
+            ORDER BY evaluation_timestamp DESC
+        ) AS _row_num
+    FROM {{ ref('stg_delta_kpi_results') }}
     {% if is_incremental() %}
     where
         date_key >= (select max(date_key) from {{ this }})
@@ -24,34 +24,34 @@ with src as (
     {% endif %}
 ),
 
-deduped as (
-    select * from src where _row_num = 1
+deduped AS (
+    SELECT * FROM src WHERE _row_num = 1
 ),
 
-dim_tbl as (
-    select __pk as table_key, table_fqn, row_effective_start, row_effective_end
-    from {{ ref('dim_delta_table') }}
+dim_tbl AS (
+    SELECT __pk AS table_key, table_fqn, row_effective_start, row_effective_end
+    FROM {{ ref('dim_delta_table') }}
 ),
 
-dim_hs as (
-    select health_status_key, status
-    from {{ ref('dim_delta_table_health_status') }}
+dim_hs AS (
+    SELECT health_status_key, status
+    FROM {{ ref('dim_delta_table_health_status') }}
 ),
 
-dim_op as (
-    select operation_type_key, operation
-    from {{ ref('dim_delta_table_operation_type') }}
+dim_op AS (
+    SELECT operation_type_key, operation
+    FROM {{ ref('dim_delta_table_operation_type') }}
 ),
 
-fact as (
-    select
-        sha2(concat_ws('|', deduped.table_fqn, deduped.snapshot_date, cast(deduped.evaluation_timestamp as string)), 256) as health_key,
+fact AS (
+    SELECT
+        sha2(concat_ws('|', deduped.table_fqn, deduped.snapshot_date, cast(deduped.evaluation_timestamp AS string)), 256) AS health_key,
         dim_tbl.table_key,
         deduped.date_key,
-        hs_overall.health_status_key as overall_status_key,
-        hs_fresh.health_status_key as freshness_status_key,
-        hs_comp.health_status_key as completeness_status_key,
-        dim_op.operation_type_key as most_common_operation_key,
+        hs_overall.health_status_key AS overall_status_key,
+        hs_fresh.health_status_key AS freshness_status_key,
+        hs_comp.health_status_key AS completeness_status_key,
+        dim_op.operation_type_key AS most_common_operation_key,
         deduped.evaluation_timestamp,
         deduped.last_commit_timestamp,
         deduped.predicted_next_commit,
@@ -67,19 +67,20 @@ fact as (
         deduped.snapshot_date,
         deduped.optimize_count_7d,
         deduped.vacuum_count_7d,
-        current_timestamp() as dbt_loaded_at,
-        date_format(current_timestamp(), 'yyyyMMdd') as event_year_date
+        current_timestamp() AS dbt_loaded_at,
+        date_format(current_timestamp(), 'yyyyMMdd') AS event_year_date
 
-    from deduped
-    inner join dim_tbl
-        on deduped.table_fqn = dim_tbl.table_fqn
-        and deduped.evaluation_timestamp >= dim_tbl.row_effective_start
-        and deduped.evaluation_timestamp < coalesce(dim_tbl.row_effective_end, cast('9999-12-31' as timestamp))
-    left join dim_hs as hs_overall on deduped.overall_status = hs_overall.status
-    left join dim_hs as hs_fresh on deduped.freshness_status = hs_fresh.status
-    left join dim_hs as hs_comp on deduped.completeness_status = hs_comp.status
-    left join dim_op on deduped.most_common_operation = dim_op.operation
+    FROM deduped
+    INNER JOIN dim_tbl
+        ON
+            deduped.table_fqn = dim_tbl.table_fqn
+            AND deduped.evaluation_timestamp >= dim_tbl.row_effective_start
+            AND deduped.evaluation_timestamp < coalesce(dim_tbl.row_effective_end, cast('9999-12-31' AS timestamp))
+    LEFT JOIN dim_hs AS hs_overall ON deduped.overall_status = hs_overall.status
+    LEFT JOIN dim_hs AS hs_fresh ON deduped.freshness_status = hs_fresh.status
+    LEFT JOIN dim_hs AS hs_comp ON deduped.completeness_status = hs_comp.status
+    LEFT JOIN dim_op ON deduped.most_common_operation = dim_op.operation
 )
 
-select * from fact
+SELECT * FROM fact
 {{ fact_not_exists('health_key', 'fact') }}

--- a/projects/spark-dbt/dbt-dataops/models/marts/fct_delta_lineage_dependency.sql
+++ b/projects/spark-dbt/dbt-dataops/models/marts/fct_delta_lineage_dependency.sql
@@ -15,8 +15,8 @@
     are intentionally nullable here (LEFT JOIN preserved by design).
 #}
 
-with src as (
-    select * from {{ ref('stg_delta_lineage') }}
+WITH src AS (
+    SELECT * FROM {{ ref('stg_delta_lineage') }}
     {% if is_incremental() %}
     where
         event_year_date >= (select date_format(max(last_seen_timestamp), 'yyyyMMdd') from {{ this }})
@@ -24,54 +24,59 @@ with src as (
     {% endif %}
 ),
 
-daily_edges as (
-    select
+daily_edges AS (
+    SELECT
         source_name,
         target_name,
         job_name,
         date_key,
-        min(event_timestamp) as first_seen_timestamp,
-        max(event_timestamp) as last_seen_timestamp,
-        count(*) as event_count
-    from src
-    group by
+        min(event_timestamp) AS first_seen_timestamp,
+        max(event_timestamp) AS last_seen_timestamp,
+        count(*) AS event_count
+    FROM src
+    GROUP BY
         source_name, target_name,
         job_name,
         date_key
 ),
 
-dim_tbl as (
-    select __pk as table_key, table_fqn, row_effective_start, row_effective_end
-    from {{ ref('dim_delta_table') }}
+dim_tbl AS (
+    SELECT __pk AS table_key, table_fqn, row_effective_start, row_effective_end
+    FROM {{ ref('dim_delta_table') }}
 ),
 
-fact as (
-    select
-        sha2(concat_ws('|',
+fact AS (
+    SELECT
+        sha2(concat_ws(
+            '|',
             de.source_name, de.target_name,
             de.job_name, de.date_key
-        ), 256) as lineage_key,
-        src_tbl.table_key as source_table_key,
-        tgt_tbl.table_key as target_table_key,
+        ), 256) AS lineage_key,
+        src_tbl.table_key AS source_table_key,
+        tgt_tbl.table_key AS target_table_key,
         de.date_key,
         de.first_seen_timestamp,
         de.last_seen_timestamp,
         de.event_count,
-        current_timestamp() as dbt_loaded_at,
-        date_format(current_timestamp(), 'yyyyMMdd') as event_year_date
+        current_timestamp() AS dbt_loaded_at,
+        date_format(current_timestamp(), 'yyyyMMdd') AS event_year_date
 
-    from daily_edges de
-    left join dim_tbl as src_tbl
-        on (de.source_name like concat('%', replace(src_tbl.table_fqn, '.', '/'), '%')
-            or de.source_name like concat('%', src_tbl.table_fqn, '%'))
-        and de.first_seen_timestamp >= src_tbl.row_effective_start
-        and de.first_seen_timestamp < coalesce(src_tbl.row_effective_end, cast('9999-12-31' as timestamp))
-    left join dim_tbl as tgt_tbl
-        on (de.target_name like concat('%', replace(tgt_tbl.table_fqn, '.', '/'), '%')
-            or de.target_name like concat('%', tgt_tbl.table_fqn, '%'))
-        and de.first_seen_timestamp >= tgt_tbl.row_effective_start
-        and de.first_seen_timestamp < coalesce(tgt_tbl.row_effective_end, cast('9999-12-31' as timestamp))
+    FROM daily_edges de
+    LEFT JOIN dim_tbl AS src_tbl
+        ON (
+            de.source_name LIKE concat('%', replace(src_tbl.table_fqn, '.', '/'), '%')
+            OR de.source_name LIKE concat('%', src_tbl.table_fqn, '%')
+        )
+        AND de.first_seen_timestamp >= src_tbl.row_effective_start
+        AND de.first_seen_timestamp < coalesce(src_tbl.row_effective_end, cast('9999-12-31' AS timestamp))
+    LEFT JOIN dim_tbl AS tgt_tbl
+        ON (
+            de.target_name LIKE concat('%', replace(tgt_tbl.table_fqn, '.', '/'), '%')
+            OR de.target_name LIKE concat('%', tgt_tbl.table_fqn, '%')
+        )
+        AND de.first_seen_timestamp >= tgt_tbl.row_effective_start
+        AND de.first_seen_timestamp < coalesce(tgt_tbl.row_effective_end, cast('9999-12-31' AS timestamp))
 )
 
-select * from fact
+SELECT * FROM fact
 {{ fact_not_exists('lineage_key', 'fact') }}

--- a/projects/spark-dbt/dbt-dataops/models/marts/fct_delta_storage.sql
+++ b/projects/spark-dbt/dbt-dataops/models/marts/fct_delta_storage.sql
@@ -9,14 +9,14 @@
     )
 }}
 
-with raw_snapshots as (
-    select
+WITH raw_snapshots AS (
+    SELECT
         *,
-        row_number() over (
-            partition by table_fqn, snapshot_date
-            order by ingested_at desc
-        ) as _row_num
-    from {{ source('dataops_inventory', 'table_snapshots') }}
+        row_number() OVER (
+            PARTITION BY table_fqn, snapshot_date
+            ORDER BY ingested_at DESC
+        ) AS _row_num
+    FROM {{ source('dataops_inventory', 'table_snapshots') }}
     {% if is_incremental() %}
     where
         snapshot_date >= (select max(date_key) from {{ this }})
@@ -24,35 +24,36 @@ with raw_snapshots as (
     {% endif %}
 ),
 
-src as (
-    select * from raw_snapshots where _row_num = 1
+src AS (
+    SELECT * FROM raw_snapshots WHERE _row_num = 1
 ),
 
-dim_tbl as (
-    select __pk as table_key, table_fqn, row_effective_start, row_effective_end
-    from {{ ref('dim_delta_table') }}
+dim_tbl AS (
+    SELECT __pk AS table_key, table_fqn, row_effective_start, row_effective_end
+    FROM {{ ref('dim_delta_table') }}
 ),
 
-fact as (
-    select
-        sha2(concat_ws('|', src.table_fqn, src.snapshot_date), 256) as storage_key,
+fact AS (
+    SELECT
+        sha2(concat_ws('|', src.table_fqn, src.snapshot_date), 256) AS storage_key,
         dim_tbl.table_key,
-        src.snapshot_date as date_key,
+        src.snapshot_date AS date_key,
         src.num_files,
         src.size_in_bytes,
         src.size_in_gb,
         src.created_at,
         src.last_modified,
         src.ingested_at,
-        current_timestamp() as dbt_loaded_at,
-        date_format(current_timestamp(), 'yyyyMMdd') as event_year_date
+        current_timestamp() AS dbt_loaded_at,
+        date_format(current_timestamp(), 'yyyyMMdd') AS event_year_date
 
-    from src
-    inner join dim_tbl
-        on src.table_fqn = dim_tbl.table_fqn
-        and src.ingested_at >= dim_tbl.row_effective_start
-        and src.ingested_at < coalesce(dim_tbl.row_effective_end, cast('9999-12-31' as timestamp))
+    FROM src
+    INNER JOIN dim_tbl
+        ON
+            src.table_fqn = dim_tbl.table_fqn
+            AND src.ingested_at >= dim_tbl.row_effective_start
+            AND src.ingested_at < coalesce(dim_tbl.row_effective_end, cast('9999-12-31' AS timestamp))
 )
 
-select * from fact
+SELECT * FROM fact
 {{ fact_not_exists('storage_key', 'fact') }}

--- a/projects/spark-dbt/dbt-dataops/models/staging/stg_delta_commit_history.sql
+++ b/projects/spark-dbt/dbt-dataops/models/staging/stg_delta_commit_history.sql
@@ -1,9 +1,9 @@
-with source as (
-    select * from {{ source('dataops_inventory', 'commit_history') }}
+WITH source AS (
+    SELECT * FROM {{ source('dataops_inventory', 'commit_history') }}
 ),
 
-cleaned as (
-    select
+cleaned AS (
+    SELECT
         table_fqn,
         database_name,
         table_name,
@@ -26,8 +26,8 @@ cleaned as (
         execution_time_ms,
         ingested_at,
         snapshot_date,
-        snapshot_date as date_key
-    from source
+        snapshot_date AS date_key
+    FROM source
 )
 
-select * from cleaned
+SELECT * FROM cleaned

--- a/projects/spark-dbt/dbt-dataops/models/staging/stg_delta_kpi_results.sql
+++ b/projects/spark-dbt/dbt-dataops/models/staging/stg_delta_kpi_results.sql
@@ -1,9 +1,9 @@
-with source as (
-    select * from {{ source('dataops_inventory', 'kpi_results') }}
+WITH source AS (
+    SELECT * FROM {{ source('dataops_inventory', 'kpi_results') }}
 ),
 
-cleaned as (
-    select
+cleaned AS (
+    SELECT
         table_fqn,
         overall_status,
         evaluation_timestamp,
@@ -24,8 +24,8 @@ cleaned as (
         optimize_count_7d,
         vacuum_count_7d,
         snapshot_date,
-        snapshot_date as date_key
-    from source
+        snapshot_date AS date_key
+    FROM source
 )
 
-select * from cleaned
+SELECT * FROM cleaned

--- a/projects/spark-dbt/dbt-dataops/models/staging/stg_delta_lineage.sql
+++ b/projects/spark-dbt/dbt-dataops/models/staging/stg_delta_lineage.sql
@@ -4,27 +4,28 @@
     )
 }}
 
-with source as (
-    select * from {{ source('dataops_inventory', 'openlineage') }}
-    where eventType = 'COMPLETE'
+WITH source AS (
+    SELECT * FROM {{ source('dataops_inventory', 'openlineage') }}
+    WHERE eventtype = 'COMPLETE'
 ),
 
-lineage_edges as (
-    select distinct
-        inputs_namespace as source_namespace,
-        inputs_name as source_name,
-        outputs_namespace as target_namespace,
-        outputs_name as target_name,
+lineage_edges AS (
+    SELECT DISTINCT
+        inputs_namespace AS source_namespace,
+        inputs_name AS source_name,
+        outputs_namespace AS target_namespace,
+        outputs_name AS target_name,
         job_name,
         job_namespace,
-        eventTime as event_timestamp,
+        eventtime AS event_timestamp,
         event_year_date,
-        event_year_date as date_key
-    from source
-    where inputs_name is not null
-      and outputs_name is not null
-      and inputs_name != ''
-      and outputs_name != ''
+        event_year_date AS date_key
+    FROM source
+    WHERE
+        inputs_name IS NOT NULL
+        AND outputs_name IS NOT NULL
+        AND inputs_name != ''
+        AND outputs_name != ''
 )
 
-select * from lineage_edges
+SELECT * FROM lineage_edges

--- a/projects/spark-dbt/dbt-dataops/models/staging/stg_delta_table_snapshots.sql
+++ b/projects/spark-dbt/dbt-dataops/models/staging/stg_delta_table_snapshots.sql
@@ -1,32 +1,32 @@
-with source as (
-    select * from {{ source('dataops_inventory', 'table_snapshots') }}
+WITH source AS (
+    SELECT * FROM {{ source('dataops_inventory', 'table_snapshots') }}
 ),
 
-ranked as (
-    select
+ranked AS (
+    SELECT
         *,
-        row_number() over (
-            partition by table_fqn
-            order by snapshot_date desc, ingested_at desc
-        ) as _row_num
-    from source
+        row_number() OVER (
+            PARTITION BY table_fqn
+            ORDER BY snapshot_date DESC, ingested_at DESC
+        ) AS _row_num
+    FROM source
 ),
 
-latest as (
-    select * from ranked where _row_num = 1
+latest AS (
+    SELECT * FROM ranked WHERE _row_num = 1
 ),
 
-cleaned as (
-    select
+cleaned AS (
+    SELECT
         table_fqn,
         database_name,
         table_name,
         table_id,
         location,
         format,
-        cast(partition_columns as string) as partition_columns,
-        cast(clustering_columns as string) as clustering_columns,
-        cast(table_properties as string) as table_properties,
+        cast(partition_columns AS string) AS partition_columns,
+        cast(clustering_columns AS string) AS clustering_columns,
+        cast(table_properties AS string) AS table_properties,
         min_reader_version,
         min_writer_version,
         num_files,
@@ -36,26 +36,28 @@ cleaned as (
         last_modified,
         ingested_at,
         snapshot_date,
-        snapshot_date as date_key,
+        snapshot_date AS date_key,
 
-        sha2(concat_ws('|',
-            coalesce(cast(clustering_columns as string), ''),
-            coalesce(cast(table_properties as string), ''),
-            coalesce(cast(min_reader_version as string), ''),
-            coalesce(cast(min_writer_version as string), '')
-        ), 256) as __scd2_hash,
+        sha2(concat_ws(
+            '|',
+            coalesce(cast(clustering_columns AS string), ''),
+            coalesce(cast(table_properties AS string), ''),
+            coalesce(cast(min_reader_version AS string), ''),
+            coalesce(cast(min_writer_version AS string), '')
+        ), 256) AS __scd2_hash,
 
-        sha2(concat_ws('|',
+        sha2(concat_ws(
+            '|',
             coalesce(table_id, ''),
             coalesce(location, ''),
             coalesce(format, ''),
-            coalesce(cast(partition_columns as string), '')
-        ), 256) as __scd1_hash,
+            coalesce(cast(partition_columns AS string), '')
+        ), 256) AS __scd1_hash,
 
-        current_date() as __merge_effective_date,
-        current_timestamp() as __merge_ingest_time
+        current_date() AS __merge_effective_date,
+        current_timestamp() AS __merge_ingest_time
 
-    from latest
+    FROM latest
 )
 
-select * from cleaned
+SELECT * FROM cleaned

--- a/projects/spark-dbt/dbt-dataops/profiles.yml
+++ b/projects/spark-dbt/dbt-dataops/profiles.yml
@@ -1,6 +1,22 @@
 dataops:
   target: local-local
   outputs:
+    # Lint-only static target (sqlfluff dbt templater) - no live Spark session
+    lint:
+      authentication: cli
+      method: livy
+      livy_mode: local
+      connect_retries: 0
+      retry_all: false
+      http_timeout: 5
+      statement_timeout: 5
+      lakehouse: dbt_dataops_dwh
+      schema: dbt_dataops_dwh
+      threads: 4
+      type: fabricspark
+      spark_config:
+        name: dbt-dataops
+
     # Local dbt client + Local spark server (default for development)
     local-local:
       authentication: cli

--- a/projects/spark-dbt/dbt-dataops/project.json
+++ b/projects/spark-dbt/dbt-dataops/project.json
@@ -27,6 +27,21 @@
           }
         ]
       }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "cache": false,
+      "inputs": [
+        "{projectRoot}/**/*",
+        "{workspaceRoot}/projects/spark-dbt/.scripts/lint-dbt.sh",
+        "{workspaceRoot}/projects/spark-dbt/.sqlfluff",
+        "{workspaceRoot}/projects/spark-dbt/pyproject.toml"
+      ],
+      "options": {
+        "cwd": "projects/spark-dbt",
+        "commands": [".scripts/lint-dbt.sh dbt-dataops"],
+        "parallel": false
+      }
     }
   }
 }

--- a/projects/spark-dbt/dbt-dataops/snapshots/snap_dim_delta_table.sql
+++ b/projects/spark-dbt/dbt-dataops/snapshots/snap_dim_delta_table.sql
@@ -12,33 +12,33 @@
     )
 }}
 
-select
+    SELECT
     -- Business key
-    table_fqn,
-    database_name,
-    table_name,
+        table_fqn,
+        database_name,
+        table_name,
 
-    -- SCD1 columns
-    table_id,
-    location,
-    format,
-    partition_columns,
+        -- SCD1 columns
+        table_id,
+        location,
+        format,
+        partition_columns,
 
-    -- SCD2 columns
-    clustering_columns,
-    table_properties,
-    min_reader_version,
-    min_writer_version,
+        -- SCD2 columns
+        clustering_columns,
+        table_properties,
+        min_reader_version,
+        min_writer_version,
 
-    -- Hash columns
-    __scd2_hash,
-    __scd1_hash,
-    __merge_effective_date,
+        -- Hash columns
+        __scd2_hash,
+        __scd1_hash,
+        __merge_effective_date,
 
-    -- Partition and audit columns
-    current_timestamp() as dbt_loaded_at,
-    date_format(current_timestamp(), 'yyyyMMdd') as event_year_date
+        -- Partition and audit columns
+        current_timestamp() AS dbt_loaded_at,
+        date_format(current_timestamp(), 'yyyyMMdd') AS event_year_date
 
-from {{ ref('stg_delta_table_snapshots') }}
+    FROM {{ ref('stg_delta_table_snapshots') }}
 
 {% endsnapshot %}

--- a/projects/spark-dbt/dbt-jaffle-shop/models/customers.sql
+++ b/projects/spark-dbt/dbt-jaffle-shop/models/customers.sql
@@ -1,69 +1,70 @@
-with customers as (
+WITH customers AS (
 
-    select * from {{ ref('stg_customers') }}
-
-),
-
-orders as (
-
-    select * from {{ ref('stg_orders') }}
+    SELECT * FROM {{ ref('stg_customers') }}
 
 ),
 
-payments as (
+orders AS (
 
-    select * from {{ ref('stg_payments') }}
+    SELECT * FROM {{ ref('stg_orders') }}
 
 ),
 
-customer_orders as (
+payments AS (
 
-        select
+    SELECT * FROM {{ ref('stg_payments') }}
+
+),
+
+customer_orders AS (
+
+    SELECT
         customer_id,
 
-        min(order_date) as first_order,
-        max(order_date) as most_recent_order,
-        count(order_id) as number_of_orders
-    from orders
+        min(order_date) AS first_order,
+        max(order_date) AS most_recent_order,
+        count(order_id) AS number_of_orders
+    FROM orders
 
-    group by customer_id
+    GROUP BY customer_id
 
 ),
 
-customer_payments as (
+customer_payments AS (
 
-    select
+    SELECT
         orders.customer_id,
-        sum(amount) as total_amount
+        sum(amount) AS total_amount
 
-    from payments
+    FROM payments
 
-    left join orders on
-         payments.order_id = orders.order_id
+    LEFT JOIN orders
+        ON
+            payments.order_id = orders.order_id
 
-    group by orders.customer_id
+    GROUP BY orders.customer_id
 
 ),
 
-final as (
+final AS (
 
-    select
+    SELECT
         customers.customer_id,
         customers.first_name,
         customers.last_name,
         customer_orders.first_order,
         customer_orders.most_recent_order,
         customer_orders.number_of_orders,
-        customer_payments.total_amount as customer_lifetime_value
+        customer_payments.total_amount AS customer_lifetime_value
 
-    from customers
+    FROM customers
 
-    left join customer_orders
-        on customers.customer_id = customer_orders.customer_id
+    LEFT JOIN customer_orders
+        ON customers.customer_id = customer_orders.customer_id
 
-    left join customer_payments
-        on  customers.customer_id = customer_payments.customer_id
+    LEFT JOIN customer_payments
+        ON customers.customer_id = customer_payments.customer_id
 
 )
 
-select * from final
+SELECT * FROM final

--- a/projects/spark-dbt/dbt-jaffle-shop/models/orders.sql
+++ b/projects/spark-dbt/dbt-jaffle-shop/models/orders.sql
@@ -1,43 +1,43 @@
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
-with orders as (
+WITH orders AS (
 
-    select * from {{ ref('stg_orders') }}
-
-),
-
-payments as (
-
-    select * from {{ ref('stg_payments') }}
+    SELECT * FROM {{ ref('stg_orders') }}
 
 ),
 
-customers as (
+payments AS (
 
-    select * from {{ ref('stg_customers') }}
+    SELECT * FROM {{ ref('stg_payments') }}
 
 ),
 
-order_payments as (
+customers AS (
 
-    select
+    SELECT * FROM {{ ref('stg_customers') }}
+
+),
+
+order_payments AS (
+
+    SELECT
         order_id,
 
         {% for payment_method in payment_methods -%}
-        sum(case when payment_method = '{{ payment_method }}' then amount else 0 end) as {{ payment_method }}_amount,
+            sum(CASE WHEN payment_method = '{{ payment_method }}' THEN amount ELSE 0 END) AS {{ payment_method }}_amount,
         {% endfor -%}
 
-        sum(amount) as total_amount
+        sum(amount) AS total_amount
 
-    from payments
+    FROM payments
 
-    group by order_id
+    GROUP BY order_id
 
 ),
 
-final as (
+final AS (
 
-    select
+    SELECT
         orders.order_id,
         orders.customer_id,
         orders.order_date,
@@ -45,21 +45,21 @@ final as (
 
         {% for payment_method in payment_methods -%}
 
-        order_payments.{{ payment_method }}_amount,
+            order_payments.{{ payment_method }}_amount,
 
         {% endfor -%}
 
-        order_payments.total_amount as amount
+        order_payments.total_amount AS amount
 
-    from orders
+    FROM orders
 
     -- FK integrity: only include orders whose customer exists
-    inner join customers
-        on orders.customer_id = customers.customer_id
+    INNER JOIN customers
+        ON orders.customer_id = customers.customer_id
 
-    left join order_payments
-        on orders.order_id = order_payments.order_id
+    LEFT JOIN order_payments
+        ON orders.order_id = order_payments.order_id
 
 )
 
-select * from final
+SELECT * FROM final

--- a/projects/spark-dbt/dbt-jaffle-shop/models/staging/stg_customers.sql
+++ b/projects/spark-dbt/dbt-jaffle-shop/models/staging/stg_customers.sql
@@ -1,31 +1,31 @@
-with source as (
+WITH source AS (
 
-    select * from {{ ref('raw_customers') }}
+    SELECT * FROM {{ ref('raw_customers') }}
 
 ),
 
-renamed as (
+renamed AS (
 
-    select
-        id as customer_id,
+    SELECT
+        id AS customer_id,
         first_name,
         last_name
 
-    from source
+    FROM source
 
 ),
 
 -- Deduplicate on natural key
-deduped as (
-    select
+deduped AS (
+    SELECT
         *,
-        row_number() over (partition by customer_id order by customer_id) as _row_num
-    from renamed
+        row_number() OVER (PARTITION BY customer_id ORDER BY customer_id) AS _row_num
+    FROM renamed
 )
 
-select
+SELECT
     customer_id,
     first_name,
     last_name
-from deduped
-where _row_num = 1
+FROM deduped
+WHERE _row_num = 1

--- a/projects/spark-dbt/dbt-jaffle-shop/models/staging/stg_orders.sql
+++ b/projects/spark-dbt/dbt-jaffle-shop/models/staging/stg_orders.sql
@@ -1,33 +1,33 @@
-with source as (
+WITH source AS (
 
-    select * from {{ ref('raw_orders') }}
+    SELECT * FROM {{ ref('raw_orders') }}
 
 ),
 
-renamed as (
+renamed AS (
 
-    select
-        id as order_id,
-        user_id as customer_id,
+    SELECT
+        id AS order_id,
+        user_id AS customer_id,
         order_date,
         status
 
-    from source
+    FROM source
 
 ),
 
 -- Deduplicate on natural key
-deduped as (
-    select
+deduped AS (
+    SELECT
         *,
-        row_number() over (partition by order_id order by order_id) as _row_num
-    from renamed
+        row_number() OVER (PARTITION BY order_id ORDER BY order_id) AS _row_num
+    FROM renamed
 )
 
-select
+SELECT
     order_id,
     customer_id,
     order_date,
     status
-from deduped
-where _row_num = 1
+FROM deduped
+WHERE _row_num = 1

--- a/projects/spark-dbt/dbt-jaffle-shop/models/staging/stg_payments.sql
+++ b/projects/spark-dbt/dbt-jaffle-shop/models/staging/stg_payments.sql
@@ -1,35 +1,35 @@
-with source as (
-    
-    select * from {{ ref('raw_payments') }}
+WITH source AS (
+
+    SELECT * FROM {{ ref('raw_payments') }}
 
 ),
 
-renamed as (
+renamed AS (
 
-    select
-        id as payment_id,
+    SELECT
+        id AS payment_id,
         order_id,
         payment_method,
 
         -- `amount` is currently stored in cents, so we convert it to dollars
-        amount / 100 as amount
+        amount / 100 AS amount
 
-    from source
+    FROM source
 
 ),
 
 -- Deduplicate on natural key
-deduped as (
-    select
+deduped AS (
+    SELECT
         *,
-        row_number() over (partition by payment_id order by payment_id) as _row_num
-    from renamed
+        row_number() OVER (PARTITION BY payment_id ORDER BY payment_id) AS _row_num
+    FROM renamed
 )
 
-select
+SELECT
     payment_id,
     order_id,
     payment_method,
     amount
-from deduped
-where _row_num = 1
+FROM deduped
+WHERE _row_num = 1

--- a/projects/spark-dbt/dbt-jaffle-shop/profiles.yml
+++ b/projects/spark-dbt/dbt-jaffle-shop/profiles.yml
@@ -1,6 +1,22 @@
 jaffle_shop:
   target: local-local
   outputs:
+    # Lint-only static target (sqlfluff dbt templater) - no live Spark session
+    lint:
+      authentication: cli
+      method: livy
+      livy_mode: local
+      connect_retries: 0
+      retry_all: false
+      http_timeout: 5
+      statement_timeout: 5
+      lakehouse: dbt_jaffle_shop_dwh
+      schema: dbt_jaffle_shop_dwh
+      threads: 4
+      type: fabricspark
+      spark_config:
+        name: dbt-jaffle-shop
+
     # Local dbt client + Local spark server (default for development)
     local-local:
       authentication: cli

--- a/projects/spark-dbt/dbt-jaffle-shop/project.json
+++ b/projects/spark-dbt/dbt-jaffle-shop/project.json
@@ -27,6 +27,21 @@
           }
         ]
       }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "cache": false,
+      "inputs": [
+        "{projectRoot}/**/*",
+        "{workspaceRoot}/projects/spark-dbt/.scripts/lint-dbt.sh",
+        "{workspaceRoot}/projects/spark-dbt/.sqlfluff",
+        "{workspaceRoot}/projects/spark-dbt/pyproject.toml"
+      ],
+      "options": {
+        "cwd": "projects/spark-dbt",
+        "commands": [".scripts/lint-dbt.sh dbt-jaffle-shop"],
+        "parallel": false
+      }
     }
   }
 }

--- a/projects/spark-dbt/dbt-reddit/models/marts/dim_author.sql
+++ b/projects/spark-dbt/dbt-reddit/models/marts/dim_author.sql
@@ -1,52 +1,52 @@
-with stg_authors as (
+WITH stg_authors AS (
 
-    select * from {{ ref('stg_authors') }}
+    SELECT * FROM {{ ref('stg_authors') }}
 
 ),
 
-deduped as (
+deduped AS (
 
-    select
+    SELECT
         *,
-        row_number() over (
-            partition by author_natural_id
-            order by fetched_at desc nulls last, run_natural_id desc nulls last
-        ) as _row_num
-    from stg_authors
+        row_number() OVER (
+            PARTITION BY author_natural_id
+            ORDER BY fetched_at DESC NULLS LAST, run_natural_id DESC NULLS LAST
+        ) AS _row_num
+    FROM stg_authors
 
 ),
 
-employees as (
+employees AS (
 
-    select * from {{ ref('stg_microsoft_employees') }}
+    SELECT * FROM {{ ref('stg_microsoft_employees') }}
 
 )
 
-select
-    {{ dbt_utils.generate_surrogate_key(['a.author_natural_id']) }} as author_key,
+SELECT
+    {{ dbt_utils.generate_surrogate_key(['a.author_natural_id']) }} AS author_key,
     a.author_natural_id,
     a.author_name,
     a.is_deleted,
-    e.username_lc is not null                                        as is_microsoft_employee,
+    e.username_lc IS NOT NULL AS is_microsoft_employee,
     e.msft_username,
     e.msft_job_title,
     e.msft_department,
-    coalesce(lower(e.msft_job_title) like '%product manager%', false) as is_product_manager,
+    coalesce(lower(e.msft_job_title) LIKE '%product manager%', FALSE) AS is_product_manager,
     a.fetched_at
-from deduped a
-left join employees e on lower(a.author_name) = e.username_lc
-where a._row_num = 1
+FROM deduped a
+LEFT JOIN employees e ON lower(a.author_name) = e.username_lc
+WHERE a._row_num = 1
 
-union all
+UNION ALL
 
-select
-    '-1'                     as author_key,
-    'UNKNOWN'                as author_natural_id,
-    'Unknown'                as author_name,
-    cast(true as boolean)    as is_deleted,
-    cast(false as boolean)   as is_microsoft_employee,
-    cast(null as string)     as msft_username,
-    cast(null as string)     as msft_job_title,
-    cast(null as string)     as msft_department,
-    cast(false as boolean)   as is_product_manager,
-    cast(null as timestamp)  as fetched_at
+SELECT
+    '-1' AS author_key,
+    'UNKNOWN' AS author_natural_id,
+    'Unknown' AS author_name,
+    cast(TRUE AS boolean) AS is_deleted,
+    cast(FALSE AS boolean) AS is_microsoft_employee,
+    cast(NULL AS string) AS msft_username,
+    cast(NULL AS string) AS msft_job_title,
+    cast(NULL AS string) AS msft_department,
+    cast(FALSE AS boolean) AS is_product_manager,
+    cast(NULL AS timestamp) AS fetched_at

--- a/projects/spark-dbt/dbt-reddit/models/marts/dim_date.sql
+++ b/projects/spark-dbt/dbt-reddit/models/marts/dim_date.sql
@@ -1,67 +1,67 @@
-with date_spine as (
+WITH date_spine AS (
 
-    select
+    SELECT
         explode(
             sequence(
-                cast('2024-01-01' as date),
-                cast('2027-12-31' as date),
-                interval 1 day
+                cast('2024-01-01' AS date),
+                cast('2027-12-31' AS date),
+                INTERVAL 1 DAY
             )
-        ) as calendar_date
+        ) AS calendar_date
 
 ),
 
-calendar as (
+calendar AS (
 
-    select
-        date_format(calendar_date, 'yyyyMMdd')   as date_key,
-        calendar_date                            as date,
-        dayofmonth(calendar_date)                as day,
-        dayofweek(calendar_date)                 as day_of_week,
-        date_format(calendar_date, 'EEEE')       as day_of_week_name,
-        dayofmonth(calendar_date)                as day_of_month,
-        dayofyear(calendar_date)                 as day_of_year,
-        weekofyear(calendar_date)                as week_of_year,
-        weekofyear(calendar_date)                as iso_week_of_year,
-        month(calendar_date)                     as month,
-        date_format(calendar_date, 'MMMM')       as month_name,
-        quarter(calendar_date)                   as quarter,
-        concat('Q', quarter(calendar_date))      as quarter_name,
-        year(calendar_date)                      as year,
-        trunc(calendar_date, 'MM')               as first_day_of_month,
-        last_day(calendar_date)                  as last_day_of_month,
-        trunc(calendar_date, 'YEAR')             as first_day_of_year,
-        make_date(year(calendar_date), 12, 31)   as last_day_of_year,
-        case when dayofweek(calendar_date) in (1, 7) then true else false end as is_weekend
-    from date_spine
+    SELECT
+        date_format(calendar_date, 'yyyyMMdd') AS date_key,
+        calendar_date AS date,
+        dayofmonth(calendar_date) AS day,
+        dayofweek(calendar_date) AS day_of_week,
+        date_format(calendar_date, 'EEEE') AS day_of_week_name,
+        dayofmonth(calendar_date) AS day_of_month,
+        dayofyear(calendar_date) AS day_of_year,
+        weekofyear(calendar_date) AS week_of_year,
+        weekofyear(calendar_date) AS iso_week_of_year,
+        month(calendar_date) AS month,
+        date_format(calendar_date, 'MMMM') AS month_name,
+        quarter(calendar_date) AS quarter,
+        concat('Q', quarter(calendar_date)) AS quarter_name,
+        year(calendar_date) AS year,
+        trunc(calendar_date, 'MM') AS first_day_of_month,
+        last_day(calendar_date) AS last_day_of_month,
+        trunc(calendar_date, 'YEAR') AS first_day_of_year,
+        make_date(year(calendar_date), 12, 31) AS last_day_of_year,
+        CASE WHEN dayofweek(calendar_date) IN (1, 7) THEN TRUE ELSE FALSE END AS is_weekend
+    FROM date_spine
 
 ),
 
-unknown_member as (
+unknown_member AS (
 
-    select
-        '-1'                       as date_key,
-        cast(null as date)         as date,
-        cast(null as int)          as day,
-        cast(null as int)          as day_of_week,
-        cast(null as string)       as day_of_week_name,
-        cast(null as int)          as day_of_month,
-        cast(null as int)          as day_of_year,
-        cast(null as int)          as week_of_year,
-        cast(null as int)          as iso_week_of_year,
-        cast(null as int)          as month,
-        cast(null as string)       as month_name,
-        cast(null as int)          as quarter,
-        cast(null as string)       as quarter_name,
-        cast(null as int)          as year,
-        cast(null as date)         as first_day_of_month,
-        cast(null as date)         as last_day_of_month,
-        cast(null as date)         as first_day_of_year,
-        cast(null as date)         as last_day_of_year,
-        cast(null as boolean)      as is_weekend
+    SELECT
+        '-1' AS date_key,
+        cast(NULL AS date) AS date,
+        cast(NULL AS int) AS day,
+        cast(NULL AS int) AS day_of_week,
+        cast(NULL AS string) AS day_of_week_name,
+        cast(NULL AS int) AS day_of_month,
+        cast(NULL AS int) AS day_of_year,
+        cast(NULL AS int) AS week_of_year,
+        cast(NULL AS int) AS iso_week_of_year,
+        cast(NULL AS int) AS month,
+        cast(NULL AS string) AS month_name,
+        cast(NULL AS int) AS quarter,
+        cast(NULL AS string) AS quarter_name,
+        cast(NULL AS int) AS year,
+        cast(NULL AS date) AS first_day_of_month,
+        cast(NULL AS date) AS last_day_of_month,
+        cast(NULL AS date) AS first_day_of_year,
+        cast(NULL AS date) AS last_day_of_year,
+        cast(NULL AS boolean) AS is_weekend
 
 )
 
-select * from calendar
-union all
-select * from unknown_member
+SELECT * FROM calendar
+UNION ALL
+SELECT * FROM unknown_member

--- a/projects/spark-dbt/dbt-reddit/models/marts/dim_fetch_run.sql
+++ b/projects/spark-dbt/dbt-reddit/models/marts/dim_fetch_run.sql
@@ -1,11 +1,11 @@
-with stg as (
+WITH stg AS (
 
-    select * from {{ ref('stg_fetch_runs') }}
+    SELECT * FROM {{ ref('stg_fetch_runs') }}
 
 )
 
-select
-    {{ dbt_utils.generate_surrogate_key(['run_natural_id']) }} as fetch_run_key,
+SELECT
+    {{ dbt_utils.generate_surrogate_key(['run_natural_id']) }} AS fetch_run_key,
     run_natural_id,
     subreddit,
     listing_type,
@@ -19,22 +19,22 @@ select
     more_calls,
     subreddits_seen,
     authors_seen
-from stg
+FROM stg
 
-union all
+UNION ALL
 
-select
-    '-1'                     as fetch_run_key,
-    cast(-1 as bigint)       as run_natural_id,
-    'Unknown'                as subreddit,
-    'Unknown'                as listing_type,
-    cast(null as string)     as time_window,
-    cast(null as int)        as limit_requested,
-    cast(null as boolean)    as skip_comments,
-    cast(null as timestamp)  as started_at,
-    cast(null as timestamp)  as finished_at,
-    cast(null as int)        as posts_ingested,
-    cast(null as int)        as comments_ingested,
-    cast(null as bigint)     as more_calls,
-    cast(null as int)        as subreddits_seen,
-    cast(null as int)        as authors_seen
+SELECT
+    '-1' AS fetch_run_key,
+    cast(-1 AS bigint) AS run_natural_id,
+    'Unknown' AS subreddit,
+    'Unknown' AS listing_type,
+    cast(NULL AS string) AS time_window,
+    cast(NULL AS int) AS limit_requested,
+    cast(NULL AS boolean) AS skip_comments,
+    cast(NULL AS timestamp) AS started_at,
+    cast(NULL AS timestamp) AS finished_at,
+    cast(NULL AS int) AS posts_ingested,
+    cast(NULL AS int) AS comments_ingested,
+    cast(NULL AS bigint) AS more_calls,
+    cast(NULL AS int) AS subreddits_seen,
+    cast(NULL AS int) AS authors_seen

--- a/projects/spark-dbt/dbt-reddit/models/marts/dim_post.sql
+++ b/projects/spark-dbt/dbt-reddit/models/marts/dim_post.sql
@@ -1,23 +1,23 @@
-with posts as (
+WITH posts AS (
 
-    select
+    SELECT
         *,
-        row_number() over (
-            partition by post_natural_id
-            order by fetched_at desc nulls last, run_natural_id desc nulls last
-        ) as _row_num
-    from {{ ref('stg_posts') }}
+        row_number() OVER (
+            PARTITION BY post_natural_id
+            ORDER BY fetched_at DESC NULLS LAST, run_natural_id DESC NULLS LAST
+        ) AS _row_num
+    FROM {{ ref('stg_posts') }}
 
 ),
 
-latest as (
+latest AS (
 
-    select * from posts where _row_num = 1
+    SELECT * FROM posts WHERE _row_num = 1
 
 )
 
-select
-    {{ dbt_utils.generate_surrogate_key(['l.post_natural_id']) }} as post_key,
+SELECT
+    {{ dbt_utils.generate_surrogate_key(['l.post_natural_id']) }} AS post_key,
     l.post_natural_id,
     l.short_id,
     l.title,
@@ -27,30 +27,30 @@ select
     l.is_self,
     l.over_18,
     l.posted_at,
-    coalesce(dd.date_key, '-1')        as posted_date_key,
-    coalesce(da.author_key, '-1')      as author_key,
-    coalesce(ds.subreddit_key, '-1')   as subreddit_key,
-    coalesce(dpf.post_flair_key, '-1') as post_flair_key
-from latest l
-left join {{ ref('dim_date') }}       dd  on dd.date_key = date_format(l.posted_at, 'yyyyMMdd')
-left join {{ ref('dim_author') }}     da  on da.author_natural_id = l.author_natural_id
-left join {{ ref('dim_subreddit') }}  ds  on ds.subreddit_natural_id = l.subreddit_natural_id
-left join {{ ref('dim_post_flair') }} dpf on dpf.flair_text = l.flair_text
+    coalesce(dd.date_key, '-1') AS posted_date_key,
+    coalesce(da.author_key, '-1') AS author_key,
+    coalesce(ds.subreddit_key, '-1') AS subreddit_key,
+    coalesce(dpf.post_flair_key, '-1') AS post_flair_key
+FROM latest l
+LEFT JOIN {{ ref('dim_date') }} dd ON dd.date_key = date_format(l.posted_at, 'yyyyMMdd')
+LEFT JOIN {{ ref('dim_author') }} da ON da.author_natural_id = l.author_natural_id
+LEFT JOIN {{ ref('dim_subreddit') }} ds ON ds.subreddit_natural_id = l.subreddit_natural_id
+LEFT JOIN {{ ref('dim_post_flair') }} dpf ON dpf.flair_text = l.flair_text
 
-union all
+UNION ALL
 
-select
-    '-1'                    as post_key,
-    'UNKNOWN'               as post_natural_id,
-    cast(null as string)    as short_id,
-    'Unknown'               as title,
-    cast(null as string)    as selftext,
-    cast(null as string)    as url,
-    cast(null as string)    as permalink,
-    cast(false as boolean)  as is_self,
-    cast(false as boolean)  as over_18,
-    cast(null as timestamp) as posted_at,
-    '-1'                    as posted_date_key,
-    '-1'                    as author_key,
-    '-1'                    as subreddit_key,
-    '-1'                    as post_flair_key
+SELECT
+    '-1' AS post_key,
+    'UNKNOWN' AS post_natural_id,
+    cast(NULL AS string) AS short_id,
+    'Unknown' AS title,
+    cast(NULL AS string) AS selftext,
+    cast(NULL AS string) AS url,
+    cast(NULL AS string) AS permalink,
+    cast(FALSE AS boolean) AS is_self,
+    cast(FALSE AS boolean) AS over_18,
+    cast(NULL AS timestamp) AS posted_at,
+    '-1' AS posted_date_key,
+    '-1' AS author_key,
+    '-1' AS subreddit_key,
+    '-1' AS post_flair_key

--- a/projects/spark-dbt/dbt-reddit/models/marts/dim_post_flair.sql
+++ b/projects/spark-dbt/dbt-reddit/models/marts/dim_post_flair.sql
@@ -1,21 +1,21 @@
-with flairs as (
+WITH flairs AS (
 
-    select distinct
+    SELECT DISTINCT
         flair_text,
         flair_category
-    from {{ ref('stg_posts') }}
+    FROM {{ ref('stg_posts') }}
 
 )
 
-select
-    {{ dbt_utils.generate_surrogate_key(['flair_text']) }} as post_flair_key,
+SELECT
+    {{ dbt_utils.generate_surrogate_key(['flair_text']) }} AS post_flair_key,
     flair_text,
     flair_category
-from flairs
+FROM flairs
 
-union all
+UNION ALL
 
-select
-    '-1'                  as post_flair_key,
-    'Unknown'             as flair_text,
-    cast(null as string)  as flair_category
+SELECT
+    '-1' AS post_flair_key,
+    'Unknown' AS flair_text,
+    cast(NULL AS string) AS flair_category

--- a/projects/spark-dbt/dbt-reddit/models/marts/dim_subreddit.sql
+++ b/projects/spark-dbt/dbt-reddit/models/marts/dim_subreddit.sql
@@ -1,35 +1,35 @@
-with stg as (
+WITH stg AS (
 
-    select * from {{ ref('stg_subreddits') }}
+    SELECT * FROM {{ ref('stg_subreddits') }}
 
 ),
 
-deduped as (
+deduped AS (
 
-    select
+    SELECT
         *,
-        row_number() over (
-            partition by subreddit_natural_id
-            order by fetched_at desc nulls last, run_natural_id desc nulls last
-        ) as _row_num
-    from stg
+        row_number() OVER (
+            PARTITION BY subreddit_natural_id
+            ORDER BY fetched_at DESC NULLS LAST, run_natural_id DESC NULLS LAST
+        ) AS _row_num
+    FROM stg
 
 )
 
-select
-    {{ dbt_utils.generate_surrogate_key(['subreddit_natural_id']) }} as subreddit_key,
+SELECT
+    {{ dbt_utils.generate_surrogate_key(['subreddit_natural_id']) }} AS subreddit_key,
     subreddit_natural_id,
     display_name,
     subscribers,
     fetched_at
-from deduped
-where _row_num = 1
+FROM deduped
+WHERE _row_num = 1
 
-union all
+UNION ALL
 
-select
-    '-1'                     as subreddit_key,
-    'UNKNOWN'                as subreddit_natural_id,
-    'Unknown'                as display_name,
-    cast(null as int)        as subscribers,
-    cast(null as timestamp)  as fetched_at
+SELECT
+    '-1' AS subreddit_key,
+    'UNKNOWN' AS subreddit_natural_id,
+    'Unknown' AS display_name,
+    cast(NULL AS int) AS subscribers,
+    cast(NULL AS timestamp) AS fetched_at

--- a/projects/spark-dbt/dbt-reddit/models/marts/fct_comment.sql
+++ b/projects/spark-dbt/dbt-reddit/models/marts/fct_comment.sql
@@ -2,22 +2,22 @@
 -- subreddit_key and post_flair_key are denormalized from dim_post so every
 -- comment can be sliced by feature area without re-joining the post.
 
-with comments as (
+WITH comments AS (
 
-    select * from {{ ref('stg_comments') }}
+    SELECT * FROM {{ ref('stg_comments') }}
 
 )
 
-select
-    {{ dbt_utils.generate_surrogate_key(['c.comment_natural_id']) }} as fct_comment_key,
-    coalesce(dp.post_key, '-1')       as post_key,
-    coalesce(da.author_key, '-1')     as author_key,
-    coalesce(dp.subreddit_key, '-1')  as subreddit_key,
-    coalesce(dp.post_flair_key, '-1') as post_flair_key,
-    coalesce(dd_c.date_key, '-1')     as commented_date_key,
-    coalesce(dd_e.date_key, '-1')     as edited_date_key,
-    coalesce(dd_f.date_key, '-1')     as fetched_date_key,
-    coalesce(dfr.fetch_run_key, '-1') as fetch_run_key,
+SELECT
+    {{ dbt_utils.generate_surrogate_key(['c.comment_natural_id']) }} AS fct_comment_key,
+    coalesce(dp.post_key, '-1') AS post_key,
+    coalesce(da.author_key, '-1') AS author_key,
+    coalesce(dp.subreddit_key, '-1') AS subreddit_key,
+    coalesce(dp.post_flair_key, '-1') AS post_flair_key,
+    coalesce(dd_c.date_key, '-1') AS commented_date_key,
+    coalesce(dd_e.date_key, '-1') AS edited_date_key,
+    coalesce(dd_f.date_key, '-1') AS fetched_date_key,
+    coalesce(dfr.fetch_run_key, '-1') AS fetch_run_key,
     c.comment_natural_id,
     c.parent_id,
     c.is_reply_to_post,
@@ -28,11 +28,11 @@ select
     c.commented_at,
     c.edited_at,
     c.score,
-    cast(1 as int)                    as comment_count
-from comments c
-left join {{ ref('dim_post') }}      dp   on dp.post_natural_id = c.post_natural_id
-left join {{ ref('dim_author') }}    da   on da.author_natural_id = c.author_natural_id
-left join {{ ref('dim_date') }}      dd_c on dd_c.date_key = date_format(c.commented_at, 'yyyyMMdd')
-left join {{ ref('dim_date') }}      dd_e on dd_e.date_key = date_format(c.edited_at, 'yyyyMMdd')
-left join {{ ref('dim_date') }}      dd_f on dd_f.date_key = date_format(c.fetched_at, 'yyyyMMdd')
-left join {{ ref('dim_fetch_run') }} dfr  on dfr.run_natural_id = c.run_natural_id
+    cast(1 AS int) AS comment_count
+FROM comments c
+LEFT JOIN {{ ref('dim_post') }} dp ON dp.post_natural_id = c.post_natural_id
+LEFT JOIN {{ ref('dim_author') }} da ON da.author_natural_id = c.author_natural_id
+LEFT JOIN {{ ref('dim_date') }} dd_c ON dd_c.date_key = date_format(c.commented_at, 'yyyyMMdd')
+LEFT JOIN {{ ref('dim_date') }} dd_e ON dd_e.date_key = date_format(c.edited_at, 'yyyyMMdd')
+LEFT JOIN {{ ref('dim_date') }} dd_f ON dd_f.date_key = date_format(c.fetched_at, 'yyyyMMdd')
+LEFT JOIN {{ ref('dim_fetch_run') }} dfr ON dfr.run_natural_id = c.run_natural_id

--- a/projects/spark-dbt/dbt-reddit/models/marts/fct_post.sql
+++ b/projects/spark-dbt/dbt-reddit/models/marts/fct_post.sql
@@ -2,31 +2,31 @@
 -- Today the source carries a single fetch_run, so this materializes as one row
 -- per post; subsequent re-fetches append snapshots without violating the grain.
 
-with posts as (
+WITH posts AS (
 
-    select * from {{ ref('stg_posts') }}
+    SELECT * FROM {{ ref('stg_posts') }}
 
 )
 
-select
-    {{ dbt_utils.generate_surrogate_key(['p.post_natural_id', 'p.run_natural_id']) }} as fct_post_key,
-    coalesce(dp.post_key, '-1')         as post_key,
-    coalesce(da.author_key, '-1')       as author_key,
-    coalesce(ds.subreddit_key, '-1')    as subreddit_key,
-    coalesce(dpf.post_flair_key, '-1')  as post_flair_key,
-    coalesce(dd_posted.date_key, '-1')  as posted_date_key,
-    coalesce(dd_fetched.date_key, '-1') as fetched_date_key,
-    coalesce(dfr.fetch_run_key, '-1')   as fetch_run_key,
+SELECT
+    {{ dbt_utils.generate_surrogate_key(['p.post_natural_id', 'p.run_natural_id']) }} AS fct_post_key,
+    coalesce(dp.post_key, '-1') AS post_key,
+    coalesce(da.author_key, '-1') AS author_key,
+    coalesce(ds.subreddit_key, '-1') AS subreddit_key,
+    coalesce(dpf.post_flair_key, '-1') AS post_flair_key,
+    coalesce(dd_posted.date_key, '-1') AS posted_date_key,
+    coalesce(dd_fetched.date_key, '-1') AS fetched_date_key,
+    coalesce(dfr.fetch_run_key, '-1') AS fetch_run_key,
     p.post_natural_id,
     p.score,
     p.upvote_ratio,
     p.num_comments,
-    cast(1 as int)                      as post_count
-from posts p
-left join {{ ref('dim_post') }}       dp         on dp.post_natural_id = p.post_natural_id
-left join {{ ref('dim_author') }}     da         on da.author_natural_id = p.author_natural_id
-left join {{ ref('dim_subreddit') }}  ds         on ds.subreddit_natural_id = p.subreddit_natural_id
-left join {{ ref('dim_post_flair') }} dpf        on dpf.flair_text = p.flair_text
-left join {{ ref('dim_date') }}       dd_posted  on dd_posted.date_key = date_format(p.posted_at, 'yyyyMMdd')
-left join {{ ref('dim_date') }}       dd_fetched on dd_fetched.date_key = date_format(p.fetched_at, 'yyyyMMdd')
-left join {{ ref('dim_fetch_run') }}  dfr        on dfr.run_natural_id = p.run_natural_id
+    cast(1 AS int) AS post_count
+FROM posts p
+LEFT JOIN {{ ref('dim_post') }} dp ON dp.post_natural_id = p.post_natural_id
+LEFT JOIN {{ ref('dim_author') }} da ON da.author_natural_id = p.author_natural_id
+LEFT JOIN {{ ref('dim_subreddit') }} ds ON ds.subreddit_natural_id = p.subreddit_natural_id
+LEFT JOIN {{ ref('dim_post_flair') }} dpf ON dpf.flair_text = p.flair_text
+LEFT JOIN {{ ref('dim_date') }} dd_posted ON dd_posted.date_key = date_format(p.posted_at, 'yyyyMMdd')
+LEFT JOIN {{ ref('dim_date') }} dd_fetched ON dd_fetched.date_key = date_format(p.fetched_at, 'yyyyMMdd')
+LEFT JOIN {{ ref('dim_fetch_run') }} dfr ON dfr.run_natural_id = p.run_natural_id

--- a/projects/spark-dbt/dbt-reddit/models/staging/stg_authors.sql
+++ b/projects/spark-dbt/dbt-reddit/models/staging/stg_authors.sql
@@ -1,14 +1,14 @@
-with source as (
+WITH source AS (
 
-    select * from {{ source('reddit_raw', 'authors') }}
+    SELECT * FROM {{ source('reddit_raw', 'authors') }}
 
 )
 
-select
-    id            as author_natural_id,
-    name          as author_name,
-    coalesce(is_deleted, false) as is_deleted,
+SELECT
+    id AS author_natural_id,
+    name AS author_name,
+    coalesce(is_deleted, FALSE) AS is_deleted,
     fetched_at,
-    fetch_run_id  as run_natural_id
-from source
-where id is not null
+    fetch_run_id AS run_natural_id
+FROM source
+WHERE id IS NOT NULL

--- a/projects/spark-dbt/dbt-reddit/models/staging/stg_comments.sql
+++ b/projects/spark-dbt/dbt-reddit/models/staging/stg_comments.sql
@@ -1,24 +1,24 @@
-with source as (
+WITH source AS (
 
-    select * from {{ source('reddit_raw', 'comments') }}
+    SELECT * FROM {{ source('reddit_raw', 'comments') }}
 
 )
 
-select
-    id            as comment_natural_id,
-    post_id       as post_natural_id,
-    author_id     as author_natural_id,
+SELECT
+    id AS comment_natural_id,
+    post_id AS post_natural_id,
+    author_id AS author_natural_id,
     parent_id,
     body,
     score,
     depth,
-    coalesce(is_submitter, false) as is_submitter,
-    coalesce(stickied, false)     as stickied,
-    created_utc   as commented_at,
-    edited_utc    as edited_at,
-    fetch_run_id  as run_natural_id,
+    coalesce(is_submitter, FALSE) AS is_submitter,
+    coalesce(stickied, FALSE) AS stickied,
+    created_utc AS commented_at,
+    edited_utc AS edited_at,
+    fetch_run_id AS run_natural_id,
     fetched_at,
-    substr(parent_id, 1, 3) = 't3_' as is_reply_to_post,
-    substr(parent_id, 1, 3) = 't1_' as is_reply_to_comment
-from source
-where id is not null
+    substr(parent_id, 1, 3) = 't3_' AS is_reply_to_post,
+    substr(parent_id, 1, 3) = 't1_' AS is_reply_to_comment
+FROM source
+WHERE id IS NOT NULL

--- a/projects/spark-dbt/dbt-reddit/models/staging/stg_fetch_runs.sql
+++ b/projects/spark-dbt/dbt-reddit/models/staging/stg_fetch_runs.sql
@@ -1,11 +1,11 @@
-with source as (
+WITH source AS (
 
-    select * from {{ source('reddit_raw', 'fetch_runs') }}
+    SELECT * FROM {{ source('reddit_raw', 'fetch_runs') }}
 
 )
 
-select
-    run_id        as run_natural_id,
+SELECT
+    run_id AS run_natural_id,
     subreddit,
     listing_type,
     time_window,
@@ -18,5 +18,5 @@ select
     more_calls,
     subreddits_seen,
     authors_seen
-from source
-where run_id is not null
+FROM source
+WHERE run_id IS NOT NULL

--- a/projects/spark-dbt/dbt-reddit/models/staging/stg_microsoft_employees.sql
+++ b/projects/spark-dbt/dbt-reddit/models/staging/stg_microsoft_employees.sql
@@ -1,14 +1,14 @@
-with source as (
+WITH source AS (
 
-    select * from {{ source('reddit_raw', 'microsoft_employees') }}
+    SELECT * FROM {{ source('reddit_raw', 'microsoft_employees') }}
 
 )
 
-select
-    lower(username)  as username_lc,
-    max(username)    as msft_username,
-    max(job_title)   as msft_job_title,
-    max(department)  as msft_department
-from source
-where username is not null
-group by lower(username)
+SELECT
+    lower(username) AS username_lc,
+    max(username) AS msft_username,
+    max(job_title) AS msft_job_title,
+    max(department) AS msft_department
+FROM source
+WHERE username IS NOT NULL
+GROUP BY lower(username)

--- a/projects/spark-dbt/dbt-reddit/models/staging/stg_posts.sql
+++ b/projects/spark-dbt/dbt-reddit/models/staging/stg_posts.sql
@@ -1,54 +1,57 @@
-with source as (
+WITH source AS (
 
-    select * from {{ source('reddit_raw', 'posts') }}
+    SELECT * FROM {{ source('reddit_raw', 'posts') }}
 
 ),
 
-renamed as (
+renamed AS (
 
-    select
-        id            as post_natural_id,
+    SELECT
+        id AS post_natural_id,
         short_id,
         title,
         selftext,
         url,
         permalink,
-        coalesce(is_self, false)   as is_self,
-        coalesce(over_18, false)   as over_18,
-        coalesce(stickied, false)  as stickied,
-        coalesce(locked, false)    as locked,
-        created_utc   as posted_at,
-        author_id     as author_natural_id,
-        subreddit_id  as subreddit_natural_id,
-        fetch_run_id  as run_natural_id,
+        coalesce(is_self, FALSE) AS is_self,
+        coalesce(over_18, FALSE) AS over_18,
+        coalesce(stickied, FALSE) AS stickied,
+        coalesce(locked, FALSE) AS locked,
+        created_utc AS posted_at,
+        author_id AS author_natural_id,
+        subreddit_id AS subreddit_natural_id,
+        fetch_run_id AS run_natural_id,
         fetched_at,
         score,
         upvote_ratio,
         num_comments,
-        coalesce(nullif(trim(flair_text), ''), '(Uncategorized)') as flair_text
-    from source
-    where id is not null
+        coalesce(nullif(trim(flair_text), ''), '(Uncategorized)') AS flair_text
+    FROM source
+    WHERE id IS NOT NULL
 
 )
 
-select
+SELECT
     *,
-    case
-        when flair_text = '(Uncategorized)' then '(Uncategorized)'
-        when lower(flair_text) like '%power bi%' then 'Power BI'
-        when lower(flair_text) like '%data engineer%'
-            or lower(flair_text) like '%data factory%'
-            or lower(flair_text) like '%data warehouse%'
-            or lower(flair_text) like '%data science%'
-            or lower(flair_text) like '%real-time%'
-            or lower(flair_text) like '%real time%'
-            or lower(flair_text) like '%database%' then 'Data Workloads'
-        when lower(flair_text) like '%community%'
-            or lower(flair_text) like '%discussion%'
-            or lower(flair_text) like '%request%' then 'Community'
-        when lower(flair_text) like '%solved%'
-            or lower(flair_text) like '%help%'
-            or lower(flair_text) like '%support%' then 'Support'
-        else 'Other'
-    end as flair_category
-from renamed
+    CASE
+        WHEN flair_text = '(Uncategorized)' THEN '(Uncategorized)'
+        WHEN lower(flair_text) LIKE '%power bi%' THEN 'Power BI'
+        WHEN
+            lower(flair_text) LIKE '%data engineer%'
+            OR lower(flair_text) LIKE '%data factory%'
+            OR lower(flair_text) LIKE '%data warehouse%'
+            OR lower(flair_text) LIKE '%data science%'
+            OR lower(flair_text) LIKE '%real-time%'
+            OR lower(flair_text) LIKE '%real time%'
+            OR lower(flair_text) LIKE '%database%' THEN 'Data Workloads'
+        WHEN
+            lower(flair_text) LIKE '%community%'
+            OR lower(flair_text) LIKE '%discussion%'
+            OR lower(flair_text) LIKE '%request%' THEN 'Community'
+        WHEN
+            lower(flair_text) LIKE '%solved%'
+            OR lower(flair_text) LIKE '%help%'
+            OR lower(flair_text) LIKE '%support%' THEN 'Support'
+        ELSE 'Other'
+    END AS flair_category
+FROM renamed

--- a/projects/spark-dbt/dbt-reddit/models/staging/stg_subreddits.sql
+++ b/projects/spark-dbt/dbt-reddit/models/staging/stg_subreddits.sql
@@ -1,15 +1,15 @@
-with source as (
+WITH source AS (
 
-    select * from {{ source('reddit_raw', 'subreddits') }}
+    SELECT * FROM {{ source('reddit_raw', 'subreddits') }}
 
 )
 
-select
-    id            as subreddit_natural_id,
+SELECT
+    id AS subreddit_natural_id,
     display_name,
     subscribers,
     created_utc,
     fetched_at,
-    fetch_run_id  as run_natural_id
-from source
-where id is not null
+    fetch_run_id AS run_natural_id
+FROM source
+WHERE id IS NOT NULL

--- a/projects/spark-dbt/dbt-reddit/profiles.yml
+++ b/projects/spark-dbt/dbt-reddit/profiles.yml
@@ -1,6 +1,22 @@
 reddit:
   target: local-local
   outputs:
+    # Lint-only static target (sqlfluff dbt templater) - no live Spark session
+    lint:
+      authentication: cli
+      method: livy
+      livy_mode: local
+      connect_retries: 0
+      retry_all: false
+      http_timeout: 5
+      statement_timeout: 5
+      lakehouse: dbt_reddit_dwh
+      schema: dbt_reddit_dwh
+      threads: 4
+      type: fabricspark
+      spark_config:
+        name: dbt-reddit
+
     # Local dbt client + Local spark server (default for development)
     local-local:
       authentication: cli

--- a/projects/spark-dbt/dbt-reddit/project.json
+++ b/projects/spark-dbt/dbt-reddit/project.json
@@ -27,6 +27,21 @@
           }
         ]
       }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "cache": false,
+      "inputs": [
+        "{projectRoot}/**/*",
+        "{workspaceRoot}/projects/spark-dbt/.scripts/lint-dbt.sh",
+        "{workspaceRoot}/projects/spark-dbt/.sqlfluff",
+        "{workspaceRoot}/projects/spark-dbt/pyproject.toml"
+      ],
+      "options": {
+        "cwd": "projects/spark-dbt",
+        "commands": [".scripts/lint-dbt.sh dbt-reddit"],
+        "parallel": false
+      }
     }
   }
 }

--- a/projects/spark-dbt/project.json
+++ b/projects/spark-dbt/project.json
@@ -19,7 +19,8 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "commands": ["black --line-length 2000 ."],
+        "cwd": "projects/spark-dbt",
+        "commands": ["black --line-length 2000 .scripts .github"],
         "parallel": false
       }
     },

--- a/projects/spark-dbt/pyproject.toml
+++ b/projects/spark-dbt/pyproject.toml
@@ -25,6 +25,8 @@ dependencies = [
   "azure-core>=1.33.0",
   "dbterd",
   "dbt-artifacts-parser",
+  "sqlfluff",
+  "sqlfluff-templater-dbt",
 ]
 
 [tool.hatch.envs.default.env-vars]


### PR DESCRIPTION
Closes #59

## What

Moves linting **into each dbt sub-project's Nx project**, and adds `sqlfluff` for SQL.

### Wiring
- `pyproject.toml`: add `sqlfluff` + `sqlfluff-templater-dbt` to the hatch venv.
- New shared `projects/spark-dbt/.sqlfluff` — dbt templater, `dialect=sparksql`, `target=lint`.
- New `.scripts/lint-dbt.sh` — `black` (Python) + `sqlfluff fix`/`lint` (SQL) over each project's `models`/`snapshots` (snapshots only when present).
- Each `dbt-<name>/profiles.yml` gains a static `lint` output (Livy-local, `connect_retries: 0`, short timeouts) so the dbt templater compiles **without** a live Spark session.
- Each `dbt-<name>/project.json` gains a `lint` target → `.scripts/lint-dbt.sh <project>`.
- Root `spark-dbt:lint` slimmed to `black --line-length 2000 .scripts .github` (covers shared Python not owned by any sub-project).

### Formatting-only guarantee
The `.sqlfluff` rule set is an **allowlist of `capitalisation` + `layout`**. Structural rewrites are intentionally **off** (CASE→COALESCE, alias/column-list removal, join-condition reordering, reference re-qualification) so lint **never changes query semantics**. Verified: all 39 changed SQL files are identical to `main` after normalizing case + whitespace (0 token-level changes).

> Note: this is a deliberate deviation from monitoring's broader `exclude_rules` list — tightened to satisfy the "format, don't change semantics" requirement. `obt_sales.sql` (`dbt_utils.star`) can't be templated statically and is skipped with a warning under `--ignore templating,parsing`.

## Validation
- `nx run-many -t lint` (all 4 projects) ✅ + root `spark-dbt:lint` ✅
- All models run locally (`local-local`): jaffle-shop **30**, reddit **106**, adventureworks **66**, dataops **79** — all `ERROR=0` ✅

## Docs
- Updated `projects/spark-dbt/.github/copilot-instructions.md` (§1 layout, §4 Nx targets, §7 Linting, §10 checklist).