### PR TITLE
refactor(dbt-runner-lib): pack dbt-runner logic into a standalone inline-YAML package

### DIFF
--- a/projects/fabric/python/dbt-runner-lib/.gitignore
+++ b/projects/fabric/python/dbt-runner-lib/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/**
+*.pyc
+.pytest_cache
+.venv
+.hatch
+dist
+build
+*.egg-info

--- a/projects/fabric/python/dbt-runner-lib/.scripts/hatch.sh
+++ b/projects/fabric/python/dbt-runner-lib/.scripts/hatch.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+#   Wrapper for hatch commands inside dbt-runner-lib.
+#
+#   Usage:
+#     ./hatch.sh clean              Clean envs and build artifacts
+#     ./hatch.sh env create         Create the default hatch env
+#     ./hatch.sh build              Build the wheel
+#     ./hatch.sh run lint:format    Run lint
+#     ./hatch.sh run test           Run tests
+#
+set -e
+
+cd "$(dirname "$0")/.."
+
+TARGET="$1"
+case "$TARGET" in
+    clean)
+        hatch env prune || true
+        rm -rf .pytest_cache .venv dist tests/__pycache__ build *.egg-info .hatch
+        ;;
+    *)
+        hatch "$@"
+        ;;
+esac

--- a/projects/fabric/python/dbt-runner-lib/README.md
+++ b/projects/fabric/python/dbt-runner-lib/README.md
@@ -1,0 +1,154 @@
+# dbt-runner-lib
+
+One **config-driven dbt execution runner** shared by local and Microsoft Fabric
+runs. Hand it a single base64-encoded inline-YAML config and it figures out
+_everything_: which dbt commands to run, dbt `--vars` injection, dbt log
+archival, node-execution metrics collection, `run_results.json` archival, the
+Delta metrics sink (local filesystem **or** OneLake abfss), and Livy session
+close.
+
+```python
+from dbt_runner import DbtRunner
+
+DbtRunner.from_base64(b64_yaml).run()   # .validate() runs in the constructor
+```
+
+The same library powers both entry points, so the two paths can never drift:
+
+| Entry point                                             | Runtime  | Target          | Metrics sink                                 |
+| ------------------------------------------------------- | -------- | --------------- | -------------------------------------------- |
+| `projects/spark-dbt/.scripts/run-dbt-local.sh`          | `local`  | `local-local`   | `projects/spark-dbt/.temp/dbt-runner/<proj>` |
+| `…/dbt_scheduler.Notebook/notebook-content.py` (Fabric) | `fabric` | `fabric-fabric` | OneLake (`abfss://…`)                        |
+
+---
+
+## The inline-YAML contract
+
+Everything is configured under one top-level `runner:` mapping. Required keys:
+`project_name`, `project_dir`, `target`, `pipeline`. Everything else has a
+documented default — see [`config/default.yaml`](config/default.yaml) for the
+fully annotated template (also printable via `python -m dbt_runner show-default`).
+
+```yaml
+runner:
+  project_name: dbt-adventureworks
+  project_dir: /tmp/dbt-fabric-bundle/projects/dbt-adventureworks
+  profiles_dir: <defaults to project_dir>
+  target: fabric-fabric
+  git_root: /tmp/dbt-fabric-bundle # optional; exported as GIT_ROOT
+  runtime: fabric # local | fabric
+
+  vars: {} # dbt --vars override (inlined)
+
+  pipeline: # declarative + ordered
+    - { command: deps }
+    - { command: debug }
+    - {
+        command: seed,
+        full_refresh: false,
+        collect_metrics: true,
+        copy_run_results: true,
+      }
+    - {
+        command: build,
+        exclude: [resource_type:seed],
+        collect_metrics: true,
+        copy_run_results: true,
+      }
+    - {
+        command: run-operation,
+        macro: cleanup_dbt_tmp_relations,
+        if_macro_exists: true,
+      }
+    - { command: docs-generate }
+
+  logging: { log_path: <dir>, archive_previous: true }
+  metrics:
+    enabled: true
+    delta_path: <dir | abfss://…> # dbt_node_executions Delta table
+    raw_path: <dir> # run_results-<cmd>.json archive
+    partition_by: [project, event_year_month]
+  session: { close: true, target: fabric-fabric }
+```
+
+### Pipeline step commands
+
+`deps`, `debug`, `seed`, `run`, `build`, `test`, `snapshot`, `compile`,
+`docs-generate`, `run-operation` (needs `macro`; supports `if_macro_exists`),
+and `shell` (needs `argv` — a generic post-hook, e.g. a validator).
+
+Per-step flags: `full_refresh`, `exclude`, `select`, `collect_metrics`,
+`copy_run_results`. `vars` is injected automatically on the commands that accept
+it.
+
+---
+
+## Public API
+
+- `DbtRunner.from_base64(s)` / `.from_yaml(s)` / `.from_path(p)` / `.from_mapping(d)`
+- `.validate() -> RunnerConfig`
+- `.run(only=None) -> RunReport` — runs the pipeline; metrics are flushed once
+  and the session closed in a `finally`-like phase so partial results survive a
+  mid-run failure. A dbt step failure takes precedence over a sink failure.
+- CLI: `python -m dbt_runner run --config-base64 <b64>` (also `--config-yaml`,
+  `--config-path`, `--only`).
+
+### Metrics parity
+
+The Arrow schema (`dbt_runner.metrics.PA_SCHEMA`) and per-node normalization are
+identical across runtimes, so a local run and a Fabric run produce the _same_
+metric rows — only the Delta path differs. Locally the table is written to the
+filesystem; in Fabric an `abfss://` or `/lakehouse/...` path is committed via the
+OneLake object-store endpoint (delta-rs cannot atomically rename on the FUSE
+mount).
+
+---
+
+## Package layout
+
+The package is organized into single-responsibility domains; each domain's
+`__init__.py` re-exports its public surface so imports are stable:
+
+```
+src/dbt_runner/
+├── __init__.py          # public API (DbtRunner, config models, errors)
+├── __main__.py          # CLI
+├── errors.py            # typed error hierarchy (cross-cutting)
+├── runner.py            # DbtRunner orchestrator + RunReport
+├── config/              # _validation · steps (StepConfig) · sections · runner (RunnerConfig) · loader
+├── runtime/             # base (RuntimeProvider) · local · fabric · factory
+├── pipeline/            # outcome · args (DbtArgsBuilder) · macros (MacroResolver) · executor (DbtPipeline)
+├── metrics/             # schema (PA_SCHEMA) · normalize · delta_sink (DeltaMetricsSink) · collector
+├── logs/                # manager (LogManager)
+└── session/             # livy · closer (SessionCloser)
+```
+
+`runner.py` composes one object per domain — `LogManager`, `DbtPipeline`,
+`MetricsCollector`, `SessionCloser`, and a `RuntimeProvider` — so each concern is
+independently testable and swappable.
+
+---
+
+## Nx targets
+
+```bash
+npx nx run dbt-runner-lib:build   # hatch wheel -> dist/
+npx nx run dbt-runner-lib:test    # pytest unit suite
+npx nx run dbt-runner-lib:lint    # black
+npx nx run dbt-runner-lib:clean
+```
+
+The wheel is bundled into `dbt-fabric-bundle.tar.gz` by
+`projects/spark-dbt/.scripts/package-fabric.sh` and pip-installed by the Fabric
+notebook. Locally, the library is an editable dependency of the `spark-dbt`
+hatch venv, so `run-dbt-local.sh` imports it directly.
+
+---
+
+## Portability
+
+The library contains **zero** repository-specific knowledge — every path,
+project name, GUID, and pipeline step lives in the injected YAML. To reuse it in
+another repository, ship the wheel and feed it a different `runner:` payload
+(`notebookutils` and `dbt-core` are treated as runtime-provided and imported
+lazily, so unit tests need neither).

--- a/projects/fabric/python/dbt-runner-lib/config/default.yaml
+++ b/projects/fabric/python/dbt-runner-lib/config/default.yaml
@@ -1,0 +1,59 @@
+# Canonical annotated configuration template for `dbt-runner-lib`.
+#
+# This file documents the full inline-YAML contract consumed by `DbtRunner`.
+# Both entry points (the local `run-dbt-local.sh` wrapper and the Fabric
+# `dbt_scheduler` notebook) build a payload of this shape, base64-encode it,
+# and hand it to `DbtRunner.from_base64(...).run()`.
+#
+# Required keys: runner.project_name, runner.project_dir, runner.target,
+# runner.pipeline. Everything else has a sensible default (shown below).
+runner:
+  # --- Identity / location ---------------------------------------------------
+  project_name: dbt-example # logical name; tags every metric row + log line
+  project_dir: /abs/path/to/projects/dbt-example # dbt project root (has dbt_project.yml)
+  profiles_dir: /abs/path/to/projects/dbt-example # defaults to project_dir
+  target: local-local # any dbt target defined in the project's profiles.yml
+  git_root: /abs/path/to/repo # optional; exported as GIT_ROOT for dbt env_var()
+  runtime: local # local | fabric — selects the token/storage provider
+
+  # --- dbt vars override (inlined) -------------------------------------------
+  # Injected as `--vars '<json>'` on seed/run/build/test/snapshot steps.
+  vars: {}
+
+  # --- Declarative pipeline (ordered) ----------------------------------------
+  # Each step is one dbt command (or a run-operation / shell hook). Per-step
+  # flags: full_refresh, exclude, select, collect_metrics, copy_run_results.
+  pipeline:
+    - command: deps
+    - command: debug
+    - command: seed
+      full_refresh: false
+      collect_metrics: true
+      copy_run_results: true
+    - command: build
+      exclude: [resource_type:seed]
+      collect_metrics: true
+      copy_run_results: true
+    - command: run-operation
+      macro: cleanup_dbt_tmp_relations
+      if_macro_exists: true # silently skipped when the macro is absent
+    - command: docs-generate
+
+  # --- Logging ---------------------------------------------------------------
+  logging:
+    log_path: /abs/path/to/logs/dbt/dbt-example # DBT_LOG_PATH; dbt.log lands here
+    archive_previous: true # rename a prior dbt.log before the run
+
+  # --- Node-execution metrics sink -------------------------------------------
+  metrics:
+    enabled: true
+    delta_path: /abs/path/to/raw/dbt/dbt_node_executions # Delta table (local fs or abfss://)
+    raw_path: /abs/path/to/metrics/dbt/dbt-example # run_results-<cmd>.json archive
+    partition_by: [project, event_year_month]
+    archive_previous_raw: true
+
+  # --- Session lifecycle (Fabric Livy close) ---------------------------------
+  session:
+    close: false # local Livy sessions are intentionally reused
+    target: local-local # profiles target whose session_id_file to read
+    endpoint: https://api.fabric.microsoft.com/v1

--- a/projects/fabric/python/dbt-runner-lib/project.json
+++ b/projects/fabric/python/dbt-runner-lib/project.json
@@ -1,0 +1,50 @@
+{
+  "name": "dbt-runner-lib",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "targets": {
+    "clean": {
+      "cache": false,
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "commands": [".scripts/hatch.sh clean"],
+        "parallel": false,
+        "forwardAllArgs": false
+      }
+    },
+    "build": {
+      "cache": false,
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "commands": [".scripts/hatch.sh env create", ".scripts/hatch.sh build"],
+        "parallel": false,
+        "forwardAllArgs": false
+      }
+    },
+    "lint": {
+      "cache": false,
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "commands": [".scripts/hatch.sh run lint:format"],
+        "parallel": false,
+        "forwardAllArgs": false
+      }
+    },
+    "test": {
+      "cache": false,
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "commands": [
+          ".scripts/hatch.sh env create",
+          ".scripts/hatch.sh run test"
+        ],
+        "parallel": false,
+        "forwardAllArgs": false
+      }
+    }
+  }
+}

--- a/projects/fabric/python/dbt-runner-lib/pyproject.toml
+++ b/projects/fabric/python/dbt-runner-lib/pyproject.toml
@@ -1,0 +1,61 @@
+# ----- Build Backend ----------------------------------------------------------
+
+[build-system]
+requires = ["hatchling>=1.17.0"]
+build-backend = "hatchling.build"
+
+# ----- Wheel layout -----------------------------------------------------------
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/dbt_runner"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"config/default.yaml" = "dbt_runner/_resources/default.yaml"
+
+# ----- Project metadata -------------------------------------------------------
+
+[project]
+name = "dbt-runner-lib"
+version = "0.1.0"
+description = "Config-driven dbt execution runner."
+readme = "README.md"
+requires-python = ">=3.10"
+license = "MIT"
+authors = [
+  { name = "Raki Rahman", email = "mdrakiburrahman@gmail.com" },
+]
+dependencies = [
+  "pyyaml>=6.0",
+  "pyarrow>=14.0",
+  "deltalake>=0.18",
+  "requests>=2.31",
+]
+
+# `dbt-core` (dbtRunner) and `notebookutils` are intentionally NOT declared
+# dependencies: dbt-core is provided by the host runtime (the spark-dbt venv
+# locally, the bundle wheels in Fabric) and imported lazily; notebookutils
+# ships only with the Fabric notebook runtime and is not pip-installable.
+
+# ----- Default env ------------------------------------------------------------
+
+[tool.hatch.envs.default]
+type = "virtual"
+path = ".venv"
+dependencies = [
+  "pytest>=8.0",
+]
+
+[tool.hatch.envs.default.scripts]
+test = "pytest {args:tests}"
+
+# ----- Lint env ---------------------------------------------------------------
+
+[tool.hatch.envs.lint]
+detached = true
+dependencies = [
+  "black",
+]
+
+[tool.hatch.envs.lint.scripts]
+format = "black --line-length 2000 {args:.}"
+check = "black --check --line-length 2000 {args:.}"

--- a/projects/fabric/python/dbt-runner-lib/src/dbt_runner/__init__.py
+++ b/projects/fabric/python/dbt-runner-lib/src/dbt_runner/__init__.py
@@ -1,0 +1,45 @@
+"""dbt-runner-lib — one config-driven dbt execution runner for local + Fabric.
+
+Hand it a base64 inline-YAML config and call ``run``::
+
+    from dbt_runner import DbtRunner
+    DbtRunner.from_base64(b64_yaml).run()
+"""
+
+from dbt_runner.config import (
+    LoggingConfig,
+    MetricsConfig,
+    RunnerConfig,
+    SessionConfig,
+    StepConfig,
+    decode_base64,
+    load_default_template,
+    load_runner_config,
+)
+from dbt_runner.errors import (
+    DbtRunnerError,
+    DbtStepError,
+    FabricRuntimeUnavailableError,
+    MetricsWriteError,
+    RunnerConfigError,
+)
+from dbt_runner.runner import DbtRunner, RunReport
+
+__all__ = [
+    "DbtRunner",
+    "RunReport",
+    "RunnerConfig",
+    "StepConfig",
+    "MetricsConfig",
+    "LoggingConfig",
+    "SessionConfig",
+    "load_runner_config",
+    "load_default_template",
+    "decode_base64",
+    "DbtRunnerError",
+    "RunnerConfigError",
+    "DbtStepError",
+    "MetricsWriteError",
+    "FabricRuntimeUnavailableError",
+]
+__version__ = "0.1.0"

--- a/projects/fabric/python/dbt-runner-lib/src/dbt_runner/__main__.py
+++ b/projects/fabric/python/dbt-runner-lib/src/dbt_runner/__main__.py
@@ -1,0 +1,57 @@
+"""Command-line entry point: ``python -m dbt_runner run --config-base64 <b64>``.
+
+Used by the local ``run-dbt-local.sh`` wrapper (and available as a fallback in
+the Fabric notebook). Keeps the surface tiny: one ``run`` subcommand that maps
+straight onto :meth:`DbtRunner.run`, plus ``show-default`` for the template.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+import yaml
+
+from dbt_runner.config import load_default_template
+from dbt_runner.errors import DbtRunnerError
+from dbt_runner.runner import DbtRunner
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="dbt_runner", description="Config-driven dbt execution runner.")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    run = sub.add_parser("run", help="Run the pipeline described by an inline-YAML config.")
+    source = run.add_mutually_exclusive_group(required=True)
+    source.add_argument("--config-base64", help="Base64-encoded inline YAML.")
+    source.add_argument("--config-yaml", help="Inline YAML string.")
+    source.add_argument("--config-path", help="Path to a YAML config file.")
+    run.add_argument("--only", nargs="+", metavar="COMMAND", help="Run only these pipeline commands (subset).")
+
+    sub.add_parser("show-default", help="Print the bundled annotated config template.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    if args.command == "show-default":
+        print(yaml.safe_dump(load_default_template(), sort_keys=False))
+        return 0
+
+    try:
+        if args.config_base64 is not None:
+            runner = DbtRunner.from_base64(args.config_base64)
+        elif args.config_yaml is not None:
+            runner = DbtRunner.from_yaml(args.config_yaml)
+        else:
+            runner = DbtRunner.from_path(args.config_path)
+        runner.run(only=args.only)
+    except DbtRunnerError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/projects/fabric/python/dbt-runner-lib/src/dbt_runner/config/__init__.py
+++ b/projects/fabric/python/dbt-runner-lib/src/dbt_runner/config/__init__.py
@@ -1,0 +1,59 @@
+"""Configuration domain: typed models + loading for the inline-YAML contract.
+
+Public symbols are re-exported here so callers and tests import from the stable
+``dbt_runner.config`` surface regardless of the internal module split.
+"""
+
+from dbt_runner.config.loader import (
+    decode_base64,
+    load_default_template,
+    load_runner_config,
+)
+from dbt_runner.config.runner import (
+    RUNTIME_FABRIC,
+    RUNTIME_LOCAL,
+    SUPPORTED_RUNTIMES,
+    RunnerConfig,
+)
+from dbt_runner.config.sections import LoggingConfig, MetricsConfig, SessionConfig
+from dbt_runner.config.steps import (
+    CMD_BUILD,
+    CMD_COMPILE,
+    CMD_DEBUG,
+    CMD_DEPS,
+    CMD_DOCS_GENERATE,
+    CMD_RUN,
+    CMD_RUN_OPERATION,
+    CMD_SEED,
+    CMD_SHELL,
+    CMD_SNAPSHOT,
+    CMD_TEST,
+    SUPPORTED_COMMANDS,
+    StepConfig,
+)
+
+__all__ = [
+    "RunnerConfig",
+    "StepConfig",
+    "LoggingConfig",
+    "MetricsConfig",
+    "SessionConfig",
+    "load_runner_config",
+    "load_default_template",
+    "decode_base64",
+    "RUNTIME_LOCAL",
+    "RUNTIME_FABRIC",
+    "SUPPORTED_RUNTIMES",
+    "SUPPORTED_COMMANDS",
+    "CMD_DEPS",
+    "CMD_DEBUG",
+    "CMD_SEED",
+    "CMD_RUN",
+    "CMD_BUILD",
+    "CMD_TEST",
+    "CMD_SNAPSHOT",
+    "CMD_COMPILE",
+    "CMD_DOCS_GENERATE",
+    "CMD_RUN_OPERATION",
+    "CMD_SHELL",
+]

--- a/projects/fabric/python/dbt-runner-lib/src/dbt_runner/config/_validation.py
+++ b/projects/fabric/python/dbt-runner-lib/src/dbt_runner/config/_validation.py
@@ -1,0 +1,37 @@
+"""Primitive validation helpers shared across the config models."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dbt_runner.errors import RunnerConfigError
+
+
+def require_non_empty_str(value: Any, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise RunnerConfigError(f"{field_name!r} must be a non-empty string, got {value!r}")
+    return value.strip()
+
+
+def as_str_tuple(value: Any, field_name: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        # A bare string is a common single-item shorthand.
+        return (value,)
+    if not isinstance(value, (list, tuple)):
+        raise RunnerConfigError(f"{field_name!r} must be a list of strings, got {type(value).__name__}")
+    out: list[str] = []
+    for i, item in enumerate(value):
+        if not isinstance(item, str) or not item.strip():
+            raise RunnerConfigError(f"{field_name}[{i}] must be a non-empty string, got {item!r}")
+        out.append(item.strip())
+    return tuple(out)
+
+
+def as_bool(value: Any, field_name: str, *, default: bool) -> bool:
+    if value is None:
+        return default
+    if not isinstance(value, bool):
+        raise RunnerConfigError(f"{field_name!r} must be a boolean, got {type(value).__name__}")
+    return value

--- a/projects/fabric/python/dbt-runner-lib/src/dbt_runner/config/loader.py
+++ b/projects/fabric/python/dbt-runner-lib/src/dbt_runner/config/loader.py
@@ -1,0 +1,89 @@
+"""Loading + decoding entry points that produce a :class:`RunnerConfig`."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import importlib.resources as resources
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from dbt_runner.config.runner import RunnerConfig
+from dbt_runner.errors import RunnerConfigError
+
+
+def _parse_payload(text: str, *, origin: str) -> dict[str, Any]:
+    try:
+        loaded = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise RunnerConfigError(f"{origin} is not valid YAML: {exc}") from exc
+    if not isinstance(loaded, dict):
+        raise RunnerConfigError(f"{origin} must parse to a mapping with a top-level 'runner' key")
+    if "runner" not in loaded:
+        raise RunnerConfigError(f"{origin} must contain a top-level 'runner' key")
+    return loaded
+
+
+def decode_base64(config_base64: str) -> str:
+    """Decode a base64 inline-YAML string to UTF-8 text (raises ``RunnerConfigError``)."""
+    if not isinstance(config_base64, str) or not config_base64.strip():
+        raise RunnerConfigError("config_base64 must be a non-empty base64 string")
+    try:
+        return base64.b64decode(config_base64.strip(), validate=True).decode("utf-8")
+    except (binascii.Error, ValueError) as exc:
+        raise RunnerConfigError(f"config_base64 is not valid base64: {exc}") from exc
+    except UnicodeDecodeError as exc:
+        raise RunnerConfigError(f"config_base64 did not decode to UTF-8 text: {exc}") from exc
+
+
+def load_runner_config(
+    *,
+    config: dict[str, Any] | None = None,
+    config_yaml: str | None = None,
+    config_base64: str | None = None,
+    config_path: str | Path | None = None,
+) -> RunnerConfig:
+    """Resolve and parse the ``runner:`` block from exactly one source.
+
+    Exactly one of ``config`` / ``config_yaml`` / ``config_base64`` /
+    ``config_path`` must be supplied — they are mutually exclusive.
+    """
+    provided = sum(1 for v in (config, config_yaml, config_base64, config_path) if v is not None)
+    if provided == 0:
+        raise RunnerConfigError("no configuration supplied; pass one of 'config', 'config_yaml', 'config_base64', or 'config_path'")
+    if provided > 1:
+        raise RunnerConfigError("pass at most one of 'config', 'config_yaml', 'config_base64', or 'config_path' — they are mutually exclusive")
+
+    if config is not None:
+        if not isinstance(config, dict):
+            raise RunnerConfigError(f"'config' must be a mapping, got {type(config).__name__}")
+        payload = config if "runner" in config else {"runner": config}
+    elif config_yaml is not None:
+        payload = _parse_payload(config_yaml, origin="config_yaml")
+    elif config_base64 is not None:
+        payload = _parse_payload(decode_base64(config_base64), origin="config_base64")
+    else:
+        path = Path(config_path)  # type: ignore[arg-type]
+        if not path.is_file():
+            raise RunnerConfigError(f"config_path {str(path)!r} does not exist")
+        payload = _parse_payload(path.read_text(), origin=f"config_path {str(path)!r}")
+
+    return RunnerConfig.from_mapping(payload["runner"])
+
+
+def load_default_template() -> dict[str, Any]:
+    """Load the bundled annotated config template (``config/default.yaml``)."""
+    pkg_files = resources.files("dbt_runner")
+    packaged = pkg_files / "_resources" / RunnerConfig._DEFAULT_RESOURCE
+    if packaged.is_file():
+        return yaml.safe_load(packaged.read_text())
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        candidate = parent / "config" / RunnerConfig._DEFAULT_RESOURCE
+        if candidate.is_file():
+            return yaml.safe_load(candidate.read_text())
+        if (parent / "pyproject.toml").is_file():
+            break
+    raise RunnerConfigError("bundled default template not found")

--- a/projects/fabric/python/dbt-runner-lib/src/dbt_runner/config/runner.py
+++ b/projects/fabric/python/dbt-runner-lib/src/dbt_runner/config/runner.py
@@ -1,0 +1,85 @@
+"""The top-level :class:`RunnerConfig` model (composes steps + sections)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, ClassVar
+
+from dbt_runner.config._validation import require_non_empty_str
+from dbt_runner.config.sections import LoggingConfig, MetricsConfig, SessionConfig
+from dbt_runner.config.steps import StepConfig
+from dbt_runner.errors import RunnerConfigError
+
+RUNTIME_LOCAL = "local"
+RUNTIME_FABRIC = "fabric"
+SUPPORTED_RUNTIMES = (RUNTIME_LOCAL, RUNTIME_FABRIC)
+
+
+@dataclass(frozen=True)
+class RunnerConfig:
+    """Top-level configuration parsed from the YAML ``runner:`` block."""
+
+    project_name: str
+    project_dir: str
+    target: str
+    profiles_dir: str
+    runtime: str = RUNTIME_LOCAL
+    git_root: str | None = None
+    vars: dict[str, Any] = field(default_factory=dict)
+    pipeline: tuple[StepConfig, ...] = ()
+    logging: LoggingConfig = field(default_factory=LoggingConfig)
+    metrics: MetricsConfig = field(default_factory=MetricsConfig)
+    session: SessionConfig = field(default_factory=SessionConfig)
+
+    _DEFAULT_RESOURCE: ClassVar[str] = "default.yaml"
+
+    @classmethod
+    def from_mapping(cls, data: Any) -> RunnerConfig:
+        if not isinstance(data, dict):
+            raise RunnerConfigError(f"'runner' must be a mapping, got {type(data).__name__}")
+
+        project_name = require_non_empty_str(data.get("project_name"), "runner.project_name")
+        project_dir = require_non_empty_str(data.get("project_dir"), "runner.project_dir")
+        target = require_non_empty_str(data.get("target"), "runner.target")
+        profiles_dir = data.get("profiles_dir")
+        profiles_dir = require_non_empty_str(profiles_dir, "runner.profiles_dir") if profiles_dir is not None else project_dir
+
+        runtime = data.get("runtime", RUNTIME_LOCAL)
+        if not isinstance(runtime, str) or runtime.strip().lower() not in SUPPORTED_RUNTIMES:
+            raise RunnerConfigError(f"runner.runtime {runtime!r} is unsupported; allowed: {', '.join(SUPPORTED_RUNTIMES)}")
+        runtime = runtime.strip().lower()
+
+        git_root = data.get("git_root")
+        if git_root is not None:
+            git_root = require_non_empty_str(git_root, "runner.git_root")
+
+        raw_vars = data.get("vars") or {}
+        if not isinstance(raw_vars, dict):
+            raise RunnerConfigError(f"runner.vars must be a mapping, got {type(raw_vars).__name__}")
+
+        raw_pipeline = data.get("pipeline")
+        if not isinstance(raw_pipeline, (list, tuple)) or not raw_pipeline:
+            raise RunnerConfigError("runner.pipeline is required and must be a non-empty list of steps")
+        pipeline = tuple(StepConfig.from_mapping(step, index=i) for i, step in enumerate(raw_pipeline))
+
+        metrics = MetricsConfig.from_mapping(data.get("metrics"))
+        if any(s.collect_metrics for s in pipeline) and not metrics.enabled:
+            raise RunnerConfigError("a pipeline step sets collect_metrics but metrics.enabled is false")
+
+        return cls(
+            project_name=project_name,
+            project_dir=project_dir,
+            target=target,
+            profiles_dir=profiles_dir,
+            runtime=runtime,
+            git_root=git_root,
+            vars=dict(raw_vars),
+            pipeline=pipeline,
+            logging=LoggingConfig.from_mapping(data.get("logging")),
+            metrics=metrics,
+            session=SessionConfig.from_mapping(data.get("session")),
+        )
+
+    @property
+    def is_fabric(self) -> bool:
+        return self.runtime == RUNTIME_FABRIC

--- a/projects/fabric/python/dbt-runner-lib/src/dbt_runner/config/sections.py
+++ b/projects/fabric/python/dbt-runner-lib/src/dbt_runner/config/sections.py
@@ -1,0 +1,90 @@
+"""Sub-section config models: logging, metrics sink, and session lifecycle."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from dbt_runner.config._validation import as_bool, as_str_tuple, require_non_empty_str
+from dbt_runner.errors import RunnerConfigError
+
+_DEFAULT_PARTITION_BY = ("project", "event_year_month")
+_DEFAULT_FABRIC_ENDPOINT = "https://api.fabric.microsoft.com/v1"
+
+
+@dataclass(frozen=True)
+class LoggingConfig:
+    log_path: str | None = None
+    archive_previous: bool = True
+
+    @classmethod
+    def from_mapping(cls, data: Any) -> LoggingConfig:
+        if data is None:
+            return cls()
+        if not isinstance(data, dict):
+            raise RunnerConfigError(f"'logging' must be a mapping, got {type(data).__name__}")
+        log_path = data.get("log_path")
+        if log_path is not None:
+            log_path = require_non_empty_str(log_path, "logging.log_path")
+        return cls(log_path=log_path, archive_previous=as_bool(data.get("archive_previous"), "logging.archive_previous", default=True))
+
+
+@dataclass(frozen=True)
+class MetricsConfig:
+    enabled: bool = True
+    delta_path: str | None = None
+    raw_path: str | None = None
+    partition_by: tuple[str, ...] = _DEFAULT_PARTITION_BY
+    archive_previous_raw: bool = True
+
+    @classmethod
+    def from_mapping(cls, data: Any) -> MetricsConfig:
+        if data is None:
+            return cls(enabled=False)
+        if not isinstance(data, dict):
+            raise RunnerConfigError(f"'metrics' must be a mapping, got {type(data).__name__}")
+        enabled = as_bool(data.get("enabled"), "metrics.enabled", default=True)
+        delta_path = data.get("delta_path")
+        raw_path = data.get("raw_path")
+        if delta_path is not None:
+            delta_path = require_non_empty_str(delta_path, "metrics.delta_path")
+        if raw_path is not None:
+            raw_path = require_non_empty_str(raw_path, "metrics.raw_path")
+        partition_by = as_str_tuple(data.get("partition_by"), "metrics.partition_by") or _DEFAULT_PARTITION_BY
+        if enabled and not delta_path:
+            raise RunnerConfigError("metrics.delta_path is required when metrics.enabled is true")
+        return cls(
+            enabled=enabled,
+            delta_path=delta_path,
+            raw_path=raw_path,
+            partition_by=partition_by,
+            archive_previous_raw=as_bool(data.get("archive_previous_raw"), "metrics.archive_previous_raw", default=True),
+        )
+
+
+@dataclass(frozen=True)
+class SessionConfig:
+    close: bool = False
+    target: str | None = None
+    endpoint: str = _DEFAULT_FABRIC_ENDPOINT
+    workspace_id: str | None = None
+    lakehouse_id: str | None = None
+
+    @classmethod
+    def from_mapping(cls, data: Any) -> SessionConfig:
+        if data is None:
+            return cls()
+        if not isinstance(data, dict):
+            raise RunnerConfigError(f"'session' must be a mapping, got {type(data).__name__}")
+        close = as_bool(data.get("close"), "session.close", default=False)
+        target = data.get("target")
+        if target is not None:
+            target = require_non_empty_str(target, "session.target")
+        endpoint = require_non_empty_str(data.get("endpoint") or _DEFAULT_FABRIC_ENDPOINT, "session.endpoint")
+        workspace_id = data.get("workspace_id")
+        lakehouse_id = data.get("lakehouse_id")
+        if workspace_id is not None:
+            workspace_id = require_non_empty_str(workspace_id, "session.workspace_id")
+        if lakehouse_id is not None:
+            lakehouse_id = require_non_empty_str(lakehouse_id, "session.lakehouse_id")
+        return cls(close=close, target=target, endpoint=endpoint.rstrip("/"), workspace_id=workspace_id, lakehouse_id=lakehouse_id)

--- a/projects/fabric/python/dbt-runner-lib/src/dbt_runner/config/steps.py
+++ b/projects/fabric/python/dbt-runner-lib/src/dbt_runner/config/steps.py
@@ -1,0 +1,123 @@
+"""Pipeline command vocabulary + the per-step :class:`StepConfig` model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from dbt_runner.config._validation import as_bool, as_str_tuple, require_non_empty_str
+from dbt_runner.errors import RunnerConfigError
+
+# --- Pipeline commands --------------------------------------------------------
+
+CMD_DEPS = "deps"
+CMD_DEBUG = "debug"
+CMD_SEED = "seed"
+CMD_RUN = "run"
+CMD_BUILD = "build"
+CMD_TEST = "test"
+CMD_SNAPSHOT = "snapshot"
+CMD_COMPILE = "compile"
+CMD_DOCS_GENERATE = "docs-generate"
+CMD_RUN_OPERATION = "run-operation"
+CMD_SHELL = "shell"
+
+SUPPORTED_COMMANDS = (
+    CMD_DEPS,
+    CMD_DEBUG,
+    CMD_SEED,
+    CMD_RUN,
+    CMD_BUILD,
+    CMD_TEST,
+    CMD_SNAPSHOT,
+    CMD_COMPILE,
+    CMD_DOCS_GENERATE,
+    CMD_RUN_OPERATION,
+    CMD_SHELL,
+)
+
+# Commands that accept dbt node selection (`--exclude` / `--select`).
+SELECTION_COMMANDS = frozenset({CMD_SEED, CMD_RUN, CMD_BUILD, CMD_TEST, CMD_SNAPSHOT, CMD_COMPILE})
+# Commands that accept `--full-refresh`.
+FULL_REFRESH_COMMANDS = frozenset({CMD_SEED, CMD_RUN, CMD_BUILD, CMD_SNAPSHOT})
+# Commands that accept `--vars`.
+VARS_COMMANDS = frozenset({CMD_SEED, CMD_RUN, CMD_BUILD, CMD_TEST, CMD_SNAPSHOT, CMD_COMPILE, CMD_RUN_OPERATION})
+
+
+@dataclass(frozen=True)
+class StepConfig:
+    """One ordered pipeline step: a dbt command, a run-operation, or a shell hook."""
+
+    command: str
+    full_refresh: bool = False
+    exclude: tuple[str, ...] = ()
+    select: tuple[str, ...] = ()
+    collect_metrics: bool = False
+    copy_run_results: bool = False
+    macro: str | None = None
+    macro_args: dict[str, Any] | None = None
+    if_macro_exists: bool = False
+    argv: tuple[str, ...] = ()
+
+    @classmethod
+    def from_mapping(cls, data: Any, *, index: int) -> StepConfig:
+        where = f"pipeline[{index}]"
+        if not isinstance(data, dict):
+            raise RunnerConfigError(f"{where} must be a mapping, got {type(data).__name__}")
+        if "command" not in data:
+            raise RunnerConfigError(f"{where} requires a 'command'")
+        command = data["command"]
+        if not isinstance(command, str) or command not in SUPPORTED_COMMANDS:
+            raise RunnerConfigError(f"{where}.command {command!r} is unsupported; allowed: {', '.join(SUPPORTED_COMMANDS)}")
+
+        full_refresh = as_bool(data.get("full_refresh"), f"{where}.full_refresh", default=False)
+        exclude = as_str_tuple(data.get("exclude"), f"{where}.exclude")
+        select = as_str_tuple(data.get("select"), f"{where}.select")
+        collect_metrics = as_bool(data.get("collect_metrics"), f"{where}.collect_metrics", default=False)
+        copy_run_results = as_bool(data.get("copy_run_results"), f"{where}.copy_run_results", default=False)
+        if_macro_exists = as_bool(data.get("if_macro_exists"), f"{where}.if_macro_exists", default=False)
+
+        macro: str | None = None
+        macro_args: dict[str, Any] | None = None
+        argv: tuple[str, ...] = ()
+
+        if command == CMD_RUN_OPERATION:
+            macro = require_non_empty_str(data.get("macro"), f"{where}.macro")
+            raw_args = data.get("macro_args")
+            if raw_args is not None:
+                if not isinstance(raw_args, dict):
+                    raise RunnerConfigError(f"{where}.macro_args must be a mapping, got {type(raw_args).__name__}")
+                macro_args = dict(raw_args)
+        elif "macro" in data:
+            raise RunnerConfigError(f"{where}.macro is only valid for command 'run-operation'")
+
+        if command == CMD_SHELL:
+            argv = as_str_tuple(data.get("argv"), f"{where}.argv")
+            if not argv:
+                raise RunnerConfigError(f"{where}.argv must be a non-empty list for command 'shell'")
+        elif "argv" in data:
+            raise RunnerConfigError(f"{where}.argv is only valid for command 'shell'")
+
+        if full_refresh and command not in FULL_REFRESH_COMMANDS:
+            raise RunnerConfigError(f"{where}.full_refresh is not valid for command {command!r}")
+        if (exclude or select) and command not in SELECTION_COMMANDS:
+            raise RunnerConfigError(f"{where} selection (exclude/select) is not valid for command {command!r}")
+        if if_macro_exists and command != CMD_RUN_OPERATION:
+            raise RunnerConfigError(f"{where}.if_macro_exists is only valid for command 'run-operation'")
+
+        return cls(
+            command=command,
+            full_refresh=full_refresh,
+            exclude=exclude,
+            select=select,
+            collect_metrics=collect_metrics,
+            copy_run_results=copy_run_results,
+            macro=macro,
+            macro_args=macro_args,
+            if_macro_exists=if_macro_exists,
+            argv=argv,
+        )
+
+    @property
+    def accepts_vars(self) -> bool:
+        return self.command in VARS_COMMANDS

--- a/projects/fabric/python/dbt-runner-lib/src/dbt_runner/errors.py
+++ b/projects/fabric/python/dbt-runner-lib/src/dbt_runner/errors.py
@@ -1,0 +1,34 @@
+"""Typed errors raised by `dbt-runner-lib`.
+
+The hierarchy is intentionally small and predictable so callers (the local
+wrapper, the Fabric notebook, and unit tests) can distinguish a bad *config*
+from a failed *dbt step* from a metrics-sink problem.
+"""
+
+from __future__ import annotations
+
+
+class DbtRunnerError(Exception):
+    """Base class for every error raised by this library."""
+
+
+class RunnerConfigError(DbtRunnerError, ValueError):
+    """Raised when the inline-YAML configuration is missing, malformed, or violates a constraint."""
+
+
+class DbtStepError(DbtRunnerError, RuntimeError):
+    """Raised when a dbt pipeline step (deps/seed/build/...) reports failure."""
+
+
+class MetricsWriteError(DbtRunnerError, RuntimeError):
+    """Raised when flushing collected node metrics to the Delta sink fails."""
+
+
+class FabricRuntimeUnavailableError(DbtRunnerError, RuntimeError):
+    """Raised when a Fabric-only feature is used outside the Fabric notebook runtime.
+
+    ``notebookutils`` ships only with the Fabric Spark / Python notebook
+    runtime and is not pip-installable, so any code path that needs it (storage
+    tokens for an abfss Delta sink, Livy session close) raises this when run on
+    a plain devbox.
+    """

--- a/projects/fabric/python/dbt-runner-lib/src/dbt_runner/logs/__init__.py
+++ b/projects/fabric/python/dbt-runner-lib/src/dbt_runner/logs/__init__.py
@@ -1,0 +1,17 @@
+"""Logging domain: dbt log archival + FUSE-safe flush."""
+
+from dbt_runner.config import RunnerConfig
+from dbt_runner.logs.manager import LogManager
+
+
+def prepare_log_path(config: RunnerConfig) -> str | None:
+    """Functional shim over :meth:`LogManager.prepare`."""
+    return LogManager(config).prepare()
+
+
+def flush_dbt_logs(dbt_log_file: str | None) -> None:
+    """Functional shim over :meth:`LogManager.flush_file`."""
+    LogManager.flush_file(dbt_log_file)
+
+
+__all__ = ["LogManager", "prepare_log_path", "flush_dbt_logs"]

--- a/projects/fabric/python/dbt-runner-lib/src/dbt_runner/logs/manager.py
+++ b/projects/fabric/python/dbt-runner-lib/src/dbt_runner/logs/manager.py
@@ -1,0 +1,72 @@
+"""dbt log-file lifecycle: archive the previous log, then flush + fsync.
+
+On a FUSE filesystem (OneLake) dbt's ``cleanup_event_logger`` clears the loggers
+without flushing, so the ``RotatingFileHandler``'s buffered writes may never
+reach the backing store. :meth:`LogManager.flush` forces a flush + fsync so logs
+survive even a mid-run crash. The same path is harmless locally.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+
+from dbt_runner.config import RunnerConfig
+
+
+class LogManager:
+    """Owns the configured ``DBT_LOG_PATH`` and the run's ``dbt.log`` file."""
+
+    def __init__(self, config: RunnerConfig) -> None:
+        self._config = config
+        self._dbt_log_file: str | None = None
+
+    @property
+    def dbt_log_file(self) -> str | None:
+        return self._dbt_log_file
+
+    def prepare(self) -> str | None:
+        """Create the configured log path, archive any previous ``dbt.log``.
+
+        Returns the absolute ``dbt.log`` path (or ``None`` when no log path is
+        configured) and exports ``DBT_LOG_PATH`` so dbt writes there.
+        """
+        log_path = self._config.logging.log_path
+        if not log_path:
+            self._dbt_log_file = None
+            return None
+
+        os.environ["DBT_LOG_PATH"] = log_path
+        os.makedirs(log_path, exist_ok=True)
+
+        dbt_log_file = os.path.join(log_path, "dbt.log")
+        if self._config.logging.archive_previous and os.path.exists(dbt_log_file):
+            ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+            archived = os.path.join(log_path, f"dbt-archived-at-{ts}.log")
+            try:
+                os.rename(dbt_log_file, archived)
+                print(f"Archived previous dbt.log to {archived}")
+            except OSError as exc:
+                print(f"Warning: failed to archive previous dbt.log: {exc}")
+        self._dbt_log_file = dbt_log_file
+        return dbt_log_file
+
+    def flush(self) -> None:
+        """Flush dbt's file logger and fsync it to persistent storage. Never raises."""
+        self.flush_file(self._dbt_log_file)
+
+    @staticmethod
+    def flush_file(dbt_log_file: str | None) -> None:
+        try:
+            from dbt_common.events.event_manager_client import get_event_manager
+
+            get_event_manager().flush()
+        except Exception:
+            pass
+        if not dbt_log_file:
+            return
+        try:
+            with open(dbt_log_file, "a") as handle:
+                os.fsync(handle.fileno())
+        except OSError:
+            pass

--- a/projects/fabric/python/dbt-runner-lib/src/dbt_runner/metrics/__init__.py
+++ b/projects/fabric/python/dbt-runner-lib/src/dbt_runner/metrics/__init__.py
@@ -1,0 +1,14 @@
+"""Metrics domain: schema, normalization, collection, and the Delta sink."""
+
+from dbt_runner.metrics.collector import MetricsCollector
+from dbt_runner.metrics.delta_sink import DeltaMetricsSink, resolve_delta_target
+from dbt_runner.metrics.normalize import normalize_node_result
+from dbt_runner.metrics.schema import PA_SCHEMA
+
+__all__ = [
+    "PA_SCHEMA",
+    "normalize_node_result",
+    "MetricsCollector",
+    "DeltaMetricsSink",
+    "resolve_delta_target",
+]

--- a/projects/fabric/python/dbt-runner-lib/src/dbt_runner/metrics/collector.py
+++ b/projects/fabric/python/dbt-runner-lib/src/dbt_runner/metrics/collector.py
@@ -1,0 +1,118 @@
+"""Buffers normalized node metrics across pipeline steps, flushes once at the end."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from datetime import datetime, timezone
+from typing import Any
+
+from dbt_runner.config import RunnerConfig
+from dbt_runner.metrics.delta_sink import DeltaMetricsSink
+from dbt_runner.metrics.normalize import (
+    normalize_node_result,
+    resolve_dbt_version,
+    resolve_invocation_id,
+)
+from dbt_runner.runtime import RuntimeProvider
+
+
+class MetricsCollector:
+    """Accumulates node-execution rows + archives ``run_results.json`` per command."""
+
+    def __init__(self, config: RunnerConfig) -> None:
+        self._config = config
+        self._buffer: list[dict[str, Any]] = []
+        self._dbt_version = resolve_dbt_version()
+        self._invocation_started_at = datetime.now(timezone.utc).replace(tzinfo=None)
+        self._sink = DeltaMetricsSink(config)
+
+    @property
+    def buffer(self) -> list[dict[str, Any]]:
+        return self._buffer
+
+    def collect(self, command: str, result: Any) -> None:
+        """Append normalized node rows from a dbtRunner result. Never raises.
+
+        deps/debug have no node results (no-op); per-node errors are printed.
+        """
+        project = self._config.project_name
+        try:
+            run_result = getattr(result, "result", None)
+            results = getattr(run_result, "results", None)
+            if not results:
+                return
+            generated_at = getattr(run_result, "generated_at", None)
+            invocation = resolve_invocation_id()
+            for r in results:
+                try:
+                    self._buffer.append(
+                        normalize_node_result(
+                            project,
+                            command,
+                            r,
+                            generated_at,
+                            invocation,
+                            dbt_version=self._dbt_version,
+                            invocation_started_at=self._invocation_started_at,
+                        )
+                    )
+                except Exception as exc:
+                    print(f"[{project}] metrics normalize ({command}) failed for one node: {exc}")
+        except Exception as exc:
+            print(f"[{project}] metrics collect ({command}) failed: {exc}")
+
+    def archive_previous_raw(self, commands: list[str]) -> None:
+        """Rename any prior ``run_results-<command>.json`` so a fresh copy can land. Never raises."""
+        raw_path = self._config.metrics.raw_path
+        if not raw_path or not self._config.metrics.archive_previous_raw:
+            return
+        for command in commands:
+            try:
+                current = os.path.join(raw_path, f"run_results-{command}.json")
+                if os.path.exists(current):
+                    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+                    archived = os.path.join(raw_path, f"run_results-{command}-archived-at-{ts}.json")
+                    os.rename(current, archived)
+                    print(f"Archived previous run_results-{command}.json to {archived}")
+            except Exception as exc:
+                print(f"Warning: failed to archive previous run_results-{command}.json: {exc}")
+
+    def copy_run_results(self, command: str) -> None:
+        """Copy dbt's ``run_results.json`` verbatim before the next command overwrites it. Never raises."""
+        raw_path = self._config.metrics.raw_path
+        if not raw_path:
+            return
+        project = self._config.project_name
+        try:
+            src = os.path.join(self._config.project_dir, "target", "run_results.json")
+            if not os.path.exists(src):
+                return
+            os.makedirs(raw_path, exist_ok=True)
+            dst = os.path.join(raw_path, f"run_results-{command}.json")
+            shutil.copyfile(src, dst)
+            try:
+                with open(dst, "a") as handle:
+                    os.fsync(handle.fileno())
+            except OSError:
+                pass
+            print(f"[{project}] archived run_results.json -> {dst}")
+        except Exception as exc:
+            print(f"[{project}] raw run_results copy ({command}) failed: {exc}")
+
+    def flush_to_delta(self, runtime: RuntimeProvider) -> int:
+        """Single append of the buffered node metrics to the Delta table.
+
+        Called once (in the cleanup phase) so partial results survive a mid-run
+        failure. Returns the number of rows written (0 when nothing buffered).
+        Raises :class:`~dbt_runner.errors.MetricsWriteError` on a hard failure.
+        """
+        project = self._config.project_name
+        if not self._config.metrics.enabled:
+            return 0
+        if not self._buffer:
+            print(f"[{project}] no node metrics to write")
+            return 0
+        written, uri = self._sink.write(self._buffer, runtime)
+        print(f"[{project}] wrote {written} node metric rows to {uri}")
+        return written

--- a/projects/fabric/python/dbt-runner-lib/src/dbt_runner/metrics/delta_sink.py
+++ b/projects/fabric/python/dbt-runner-lib/src/dbt_runner/metrics/delta_sink.py
@@ -1,0 +1,73 @@
+"""Delta sink for node metrics: resolve the target URI, then append rows.
+
+The OneLake FUSE mount (``/lakehouse/...``) cannot be used by delta-rs: its
+commit step needs an atomic rename the FUSE driver rejects ("Operation not
+permitted"). So a OneLake FUSE path is rewritten to the abfss object-store
+endpoint (committed via ADLS). An ``abfss://`` path is used as-is; any other
+(genuinely local) path is written directly with no storage options.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import pyarrow as pa
+
+from dbt_runner.config import RunnerConfig
+from dbt_runner.errors import MetricsWriteError
+from dbt_runner.metrics.schema import PA_SCHEMA
+from dbt_runner.runtime import RuntimeProvider
+
+_ONELAKE_FUSE_PREFIX = "/lakehouse/default/Files/"
+
+
+def resolve_delta_target(delta_path: str, runtime: RuntimeProvider) -> tuple[str, dict[str, str] | None]:
+    """Map ``delta_path`` to ``(uri, storage_options)`` for ``write_deltalake``.
+
+    For a local target the parent directory is created eagerly so the first
+    Delta commit succeeds.
+    """
+    if delta_path.startswith("abfss://"):
+        return delta_path, runtime.storage_options()
+
+    if delta_path.startswith(_ONELAKE_FUSE_PREFIX):
+        workspace_id, lakehouse_id = runtime.onelake_context()
+        if not workspace_id or not lakehouse_id:
+            raise MetricsWriteError(f"cannot rewrite OneLake FUSE path {delta_path!r} to abfss: workspace/lakehouse id unavailable (is runtime 'fabric'?)")
+        rel = delta_path[len(_ONELAKE_FUSE_PREFIX) :]
+        uri = f"abfss://{workspace_id}@onelake.dfs.fabric.microsoft.com/{lakehouse_id}/Files/{rel}"
+        return uri, runtime.storage_options()
+
+    os.makedirs(os.path.dirname(delta_path) or ".", exist_ok=True)
+    return delta_path, None
+
+
+class DeltaMetricsSink:
+    """Appends ``PA_SCHEMA``-shaped rows to the configured metrics Delta table."""
+
+    def __init__(self, config: RunnerConfig) -> None:
+        self._config = config
+
+    def write(self, rows: list[dict[str, Any]], runtime: RuntimeProvider) -> tuple[int, str]:
+        """Append ``rows`` and return ``(row_count, resolved_uri)``.
+
+        Raises :class:`MetricsWriteError` on any hard write failure.
+        """
+        delta_path = self._config.metrics.delta_path
+        if not delta_path:
+            raise MetricsWriteError("metrics.delta_path is not set but metrics were collected")
+        try:
+            from deltalake import write_deltalake
+
+            uri, storage_options = resolve_delta_target(delta_path, runtime)
+            table = pa.Table.from_pylist(rows, schema=PA_SCHEMA)
+            kwargs: dict[str, Any] = {"mode": "append", "partition_by": list(self._config.metrics.partition_by)}
+            if storage_options is not None:
+                kwargs["storage_options"] = storage_options
+            write_deltalake(uri, table, **kwargs)
+            return len(rows), uri
+        except MetricsWriteError:
+            raise
+        except Exception as exc:
+            raise MetricsWriteError(f"[{self._config.project_name}] metrics delta flush failed: {exc}") from exc

--- a/projects/fabric/python/dbt-runner-lib/src/dbt_runner/metrics/normalize.py
+++ b/projects/fabric/python/dbt-runner-lib/src/dbt_runner/metrics/normalize.py
@@ -1,0 +1,112 @@
+"""Flatten a single ``dbtRunner`` node result into a ``PA_SCHEMA``-shaped dict."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Any
+
+
+def resolve_dbt_version() -> str:
+    try:
+        from dbt.version import __version__ as version
+
+        return version
+    except Exception:
+        return "unknown"
+
+
+def resolve_invocation_id() -> str | None:
+    try:
+        from dbt_common.invocation import get_invocation_id
+
+        return get_invocation_id()
+    except Exception:
+        return None
+
+
+def _safe_json(obj: Any) -> str | None:
+    """Serialize anything to a JSON string, never raising."""
+    if obj is None:
+        return None
+    try:
+        return json.dumps(obj, default=str)
+    except Exception:
+        try:
+            return json.dumps(str(obj))
+        except Exception:
+            return None
+
+
+def _seconds_between(start: Any, end: Any) -> float | None:
+    if start is not None and end is not None:
+        return (end - start).total_seconds()
+    return None
+
+
+def normalize_node_result(
+    project: str,
+    command: str,
+    r: Any,
+    generated_at: Any,
+    invocation_id: str | None,
+    *,
+    dbt_version: str,
+    invocation_started_at: datetime,
+) -> dict[str, Any]:
+    node = getattr(r, "node", None)
+    cfg = getattr(node, "config", None)
+
+    compile_started = compile_completed = execute_started = execute_completed = None
+    for ti in getattr(r, "timing", None) or []:
+        if ti.name == "compile":
+            compile_started, compile_completed = ti.started_at, ti.completed_at
+        elif ti.name == "execute":
+            execute_started, execute_completed = ti.started_at, ti.completed_at
+
+    adapter = getattr(r, "adapter_response", None) or {}
+    rows_affected = adapter.get("rows_affected") if isinstance(adapter, dict) else None
+    failures = getattr(r, "failures", None)
+
+    depends_on = getattr(node, "depends_on", None)
+    depends_on_nodes = list(getattr(depends_on, "nodes", None) or []) if depends_on is not None else []
+    test_metadata = getattr(node, "test_metadata", None)
+
+    part_dt = execute_completed or generated_at or invocation_started_at
+
+    return {
+        "project": project,
+        "command": command,
+        "invocation_id": invocation_id,
+        "dbt_version": dbt_version,
+        "generated_at": generated_at,
+        "unique_id": getattr(node, "unique_id", None),
+        "resource_type": str(getattr(node, "resource_type", "") or "") or None,
+        "package_name": getattr(node, "package_name", None),
+        "name": getattr(node, "name", None),
+        "alias": getattr(node, "alias", None),
+        "database": getattr(node, "database", None),
+        "schema_name": getattr(node, "schema", None),
+        "relation_name": getattr(node, "relation_name", None),
+        "original_file_path": getattr(node, "original_file_path", None),
+        "materialized": getattr(cfg, "materialized", None),
+        "execution_time": getattr(r, "execution_time", None),
+        "compile_started_at": compile_started,
+        "compile_completed_at": compile_completed,
+        "compile_time": _seconds_between(compile_started, compile_completed),
+        "execute_started_at": execute_started,
+        "execute_completed_at": execute_completed,
+        "execute_time": _seconds_between(execute_started, execute_completed),
+        "thread_id": getattr(r, "thread_id", None),
+        "status": str(getattr(r, "status", "") or "") or None,
+        "rows_affected": int(rows_affected) if isinstance(rows_affected, (int, float)) else None,
+        "failures": int(failures) if failures is not None else None,
+        "message": getattr(r, "message", None),
+        "tags": list(getattr(node, "tags", None) or []),
+        "depends_on_nodes": depends_on_nodes,
+        "adapter_response_json": _safe_json(adapter),
+        "config_json": _safe_json(cfg.to_dict() if hasattr(cfg, "to_dict") else cfg),
+        "test_metadata_json": _safe_json(test_metadata.to_dict() if hasattr(test_metadata, "to_dict") else test_metadata),
+        "raw_json": _safe_json(r.to_dict() if hasattr(r, "to_dict") else None),
+        "event_year_month": part_dt.strftime("%Y%m") if part_dt is not None else None,
+    }

--- a/projects/fabric/python/dbt-runner-lib/src/dbt_runner/metrics/schema.py
+++ b/projects/fabric/python/dbt-runner-lib/src/dbt_runner/metrics/schema.py
@@ -1,0 +1,48 @@
+"""The Arrow schema for the ``dbt_node_executions`` metrics table.
+
+Kept byte-for-byte identical across local and Fabric runs so both produce the
+same rows — only the Delta sink path differs.
+"""
+
+from __future__ import annotations
+
+import pyarrow as pa
+
+PA_SCHEMA = pa.schema(
+    [
+        ("project", pa.string()),
+        ("command", pa.string()),
+        ("invocation_id", pa.string()),
+        ("dbt_version", pa.string()),
+        ("generated_at", pa.timestamp("us", tz="UTC")),
+        ("unique_id", pa.string()),
+        ("resource_type", pa.string()),
+        ("package_name", pa.string()),
+        ("name", pa.string()),
+        ("alias", pa.string()),
+        ("database", pa.string()),
+        ("schema_name", pa.string()),
+        ("relation_name", pa.string()),
+        ("original_file_path", pa.string()),
+        ("materialized", pa.string()),
+        ("execution_time", pa.float64()),
+        ("compile_started_at", pa.timestamp("us", tz="UTC")),
+        ("compile_completed_at", pa.timestamp("us", tz="UTC")),
+        ("compile_time", pa.float64()),
+        ("execute_started_at", pa.timestamp("us", tz="UTC")),
+        ("execute_completed_at", pa.timestamp("us", tz="UTC")),
+        ("execute_time", pa.float64()),
+        ("thread_id", pa.string()),
+        ("status", pa.string()),
+        ("rows_affected", pa.int64()),
+        ("failures", pa.int64()),
+        ("message", pa.string()),
+        ("tags", pa.list_(pa.string())),
+        ("depends_on_nodes", pa.list_(pa.string())),
+        ("adapter_response_json", pa.string()),
+        ("config_json", pa.string()),
+        ("test_metadata_json", pa.string()),
+        ("raw_json", pa.string()),
+        ("event_year_month", pa.string()),
+    ]
+)

--- a/projects/fabric/python/dbt-runner-lib/src/dbt_runner/pipeline/__init__.py
+++ b/projects/fabric/python/dbt-runner-lib/src/dbt_runner/pipeline/__init__.py
@@ -1,0 +1,17 @@
+"""Pipeline domain: arg-building, macro resolution, and step execution."""
+
+from dbt_runner.pipeline.args import DbtArgsBuilder, build_dbt_args
+from dbt_runner.pipeline.executor import DbtInvoke, DbtPipeline, ShellInvoke
+from dbt_runner.pipeline.macros import MacroResolver, macro_exists
+from dbt_runner.pipeline.outcome import StepOutcome
+
+__all__ = [
+    "DbtPipeline",
+    "StepOutcome",
+    "DbtArgsBuilder",
+    "build_dbt_args",
+    "MacroResolver",
+    "macro_exists",
+    "DbtInvoke",
+    "ShellInvoke",
+]

--- a/projects/fabric/python/dbt-runner-lib/src/dbt_runner/pipeline/args.py
+++ b/projects/fabric/python/dbt-runner-lib/src/dbt_runner/pipeline/args.py
@@ -1,0 +1,49 @@
+"""Assemble the dbt CLI argv for a step (project/profiles/target + flags + vars)."""
+
+from __future__ import annotations
+
+import json
+
+from dbt_runner.config import (
+    CMD_DOCS_GENERATE,
+    CMD_RUN_OPERATION,
+    RunnerConfig,
+    StepConfig,
+)
+
+
+class DbtArgsBuilder:
+    """Builds the ``dbtRunner.invoke`` argv for a step under a given config."""
+
+    def __init__(self, config: RunnerConfig) -> None:
+        self._config = config
+
+    @staticmethod
+    def _leading_tokens(step: StepConfig) -> list[str]:
+        if step.command == CMD_DOCS_GENERATE:
+            return ["docs", "generate"]
+        if step.command == CMD_RUN_OPERATION:
+            return ["run-operation", step.macro]  # type: ignore[list-item]
+        return [step.command]
+
+    def build(self, step: StepConfig) -> list[str]:
+        config = self._config
+        args = self._leading_tokens(step)
+        args += ["--project-dir", config.project_dir, "--profiles-dir", config.profiles_dir, "--target", config.target]
+
+        if step.select:
+            args += ["--select", " ".join(step.select)]
+        if step.exclude:
+            args += ["--exclude", " ".join(step.exclude)]
+        if step.full_refresh:
+            args += ["--full-refresh"]
+        if step.command == CMD_RUN_OPERATION and step.macro_args:
+            args += ["--args", json.dumps(step.macro_args)]
+        if step.accepts_vars and config.vars:
+            args += ["--vars", json.dumps(config.vars)]
+        return args
+
+
+def build_dbt_args(step: StepConfig, config: RunnerConfig) -> list[str]:
+    """Functional shim over :meth:`DbtArgsBuilder.build`."""
+    return DbtArgsBuilder(config).build(step)

--- a/projects/fabric/python/dbt-runner-lib/src/dbt_runner/pipeline/executor.py
+++ b/projects/fabric/python/dbt-runner-lib/src/dbt_runner/pipeline/executor.py
@@ -1,0 +1,75 @@
+"""Executes pipeline steps via the in-process ``dbtRunner`` API + shell hooks.
+
+``dbtRunner`` is imported lazily and the invoke callables are injectable, so unit
+tests exercise control flow without dbt installed.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Any, Callable
+
+from dbt_runner.config import CMD_RUN_OPERATION, CMD_SHELL, RunnerConfig, StepConfig
+from dbt_runner.pipeline.args import DbtArgsBuilder
+from dbt_runner.pipeline.macros import MacroResolver
+from dbt_runner.pipeline.outcome import StepOutcome
+
+# A dbt invocation: takes the assembled argv, returns a dbtRunner result object.
+DbtInvoke = Callable[[list[str]], Any]
+# A shell invocation: takes argv + cwd, returns a completed-process-like object.
+ShellInvoke = Callable[[list[str], str], Any]
+
+
+def _default_dbt_invoke(args: list[str]) -> Any:
+    from dbt.cli.main import dbtRunner
+
+    return dbtRunner().invoke(args)
+
+
+def _default_shell_invoke(argv: list[str], cwd: str) -> Any:
+    return subprocess.run(argv, cwd=cwd, check=False)
+
+
+class DbtPipeline:
+    """Runs steps; the dbt/shell invokers are injectable for tests."""
+
+    def __init__(
+        self,
+        config: RunnerConfig,
+        *,
+        dbt_invoke: DbtInvoke | None = None,
+        shell_invoke: ShellInvoke | None = None,
+    ) -> None:
+        self._config = config
+        self._args = DbtArgsBuilder(config)
+        self._macros = MacroResolver(config.project_dir)
+        self._dbt_invoke = dbt_invoke or _default_dbt_invoke
+        self._shell_invoke = shell_invoke or _default_shell_invoke
+
+    def invoke(self, step: StepConfig) -> StepOutcome:
+        if step.command == CMD_SHELL:
+            return self._invoke_shell(step)
+        if step.command == CMD_RUN_OPERATION and step.if_macro_exists and not self._macros.exists(step.macro or ""):
+            print(f"[{self._config.project_name}] run-operation {step.macro}: skipped (macro not found)")
+            return StepOutcome(command=step.command, success=True, skipped=True)
+        return self._invoke_dbt(step)
+
+    def _invoke_dbt(self, step: StepConfig) -> StepOutcome:
+        result = self._dbt_invoke(self._args.build(step))
+        success = bool(getattr(result, "success", False))
+        detail = ""
+        if not success:
+            exception = getattr(result, "exception", None)
+            if exception:
+                detail += f"\n  Exception: {exception}"
+            inner = getattr(result, "result", None)
+            if inner:
+                detail += f"\n  Result: {inner}"
+        return StepOutcome(command=step.command, success=success, dbt_result=result, detail=detail)
+
+    def _invoke_shell(self, step: StepConfig) -> StepOutcome:
+        completed = self._shell_invoke(list(step.argv), self._config.project_dir)
+        returncode = getattr(completed, "returncode", 1)
+        success = returncode == 0
+        detail = "" if success else f"\n  shell exit code: {returncode}"
+        return StepOutcome(command=step.command, success=success, detail=detail)

--- a/projects/fabric/python/dbt-runner-lib/src/dbt_runner/pipeline/macros.py
+++ b/projects/fabric/python/dbt-runner-lib/src/dbt_runner/pipeline/macros.py
@@ -1,0 +1,31 @@
+"""Resolve whether a dbt macro is defined in a project's ``macros/`` tree."""
+
+from __future__ import annotations
+
+import glob
+import os
+
+
+class MacroResolver:
+    """Looks up ``{% macro <name> %}`` definitions under ``<project_dir>/macros``."""
+
+    def __init__(self, project_dir: str) -> None:
+        self._macros_dir = os.path.join(project_dir, "macros")
+
+    def exists(self, macro: str) -> bool:
+        if not os.path.isdir(self._macros_dir):
+            return False
+        needle = f"macro {macro}"
+        for path in glob.glob(os.path.join(self._macros_dir, "**", "*.sql"), recursive=True):
+            try:
+                with open(path, "r", encoding="utf-8", errors="ignore") as handle:
+                    if needle in handle.read():
+                        return True
+            except OSError:
+                continue
+        return False
+
+
+def macro_exists(project_dir: str, macro: str) -> bool:
+    """Functional shim over :meth:`MacroResolver.exists`."""
+    return MacroResolver(project_dir).exists(macro)

--- a/projects/fabric/python/dbt-runner-lib/src/dbt_runner/pipeline/outcome.py
+++ b/projects/fabric/python/dbt-runner-lib/src/dbt_runner/pipeline/outcome.py
@@ -1,0 +1,17 @@
+"""The result object for a single executed pipeline step."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class StepOutcome:
+    """Result of executing one pipeline step."""
+
+    command: str
+    success: bool
+    skipped: bool = False
+    dbt_result: Any = None
+    detail: str = ""

--- a/projects/fabric/python/dbt-runner-lib/src/dbt_runner/runner.py
+++ b/projects/fabric/python/dbt-runner-lib/src/dbt_runner/runner.py
@@ -1,0 +1,155 @@
+"""`DbtRunner` — the single entry point.
+
+Decodes one inline-YAML config, validates it, and runs the declared pipeline:
+per-step dbt invocation → log flush → metric collection → run_results archival,
+then a single metrics flush to Delta and an optional Livy session close.
+
+Usage::
+
+    from dbt_runner import DbtRunner
+    DbtRunner.from_base64(b64_yaml).run()
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from dbt_runner.config import RunnerConfig, StepConfig, load_runner_config
+from dbt_runner.errors import DbtStepError, MetricsWriteError, RunnerConfigError
+from dbt_runner.logs import LogManager
+from dbt_runner.metrics import MetricsCollector
+from dbt_runner.pipeline import DbtInvoke, DbtPipeline, ShellInvoke, StepOutcome
+from dbt_runner.runtime import RuntimeProvider, make_runtime
+from dbt_runner.session import HttpDelete, SessionCloser
+
+
+@dataclass
+class RunReport:
+    """Outcome of a :meth:`DbtRunner.run` call."""
+
+    project_name: str
+    outcomes: list[StepOutcome] = field(default_factory=list)
+    metric_rows_written: int = 0
+
+    @property
+    def success(self) -> bool:
+        return all(o.success for o in self.outcomes)
+
+
+class DbtRunner:
+    """Config-driven dbt execution engine. Test doubles are injectable by keyword."""
+
+    def __init__(
+        self,
+        config: RunnerConfig,
+        *,
+        dbt_invoke: DbtInvoke | None = None,
+        shell_invoke: ShellInvoke | None = None,
+        http_delete: HttpDelete | None = None,
+        runtime: RuntimeProvider | None = None,
+    ) -> None:
+        if not isinstance(config, RunnerConfig):
+            raise RunnerConfigError(f"DbtRunner requires a RunnerConfig, got {type(config).__name__}")
+        self._config = config
+        self._dbt_invoke = dbt_invoke
+        self._shell_invoke = shell_invoke
+        self._http_delete = http_delete
+        self._runtime_override = runtime
+
+    # --- Constructors ---------------------------------------------------------
+
+    @classmethod
+    def from_base64(cls, config_base64: str, **kwargs: Any) -> DbtRunner:
+        return cls(load_runner_config(config_base64=config_base64), **kwargs)
+
+    @classmethod
+    def from_yaml(cls, config_yaml: str, **kwargs: Any) -> DbtRunner:
+        return cls(load_runner_config(config_yaml=config_yaml), **kwargs)
+
+    @classmethod
+    def from_path(cls, config_path: str | Path, **kwargs: Any) -> DbtRunner:
+        return cls(load_runner_config(config_path=config_path), **kwargs)
+
+    @classmethod
+    def from_mapping(cls, config: dict[str, Any], **kwargs: Any) -> DbtRunner:
+        return cls(load_runner_config(config=config), **kwargs)
+
+    # --- Public API -----------------------------------------------------------
+
+    @property
+    def config(self) -> RunnerConfig:
+        return self._config
+
+    def validate(self) -> RunnerConfig:
+        """Return the validated config (validation already ran at construction)."""
+        return self._config
+
+    def run(self, only: list[str] | None = None) -> RunReport:
+        """Execute the configured pipeline and return a :class:`RunReport`.
+
+        Metrics are flushed and the session closed in a ``finally``-like phase so
+        partial results survive a mid-run failure. A dbt step failure takes
+        precedence over a metrics-sink failure when both occur.
+        """
+        config = self._config
+        self._prepare_environment()
+        logs = LogManager(config)
+        logs.prepare()
+
+        runtime = self._runtime_override or make_runtime(config)
+        pipeline = DbtPipeline(config, dbt_invoke=self._dbt_invoke, shell_invoke=self._shell_invoke)
+        collector = MetricsCollector(config)
+        closer = SessionCloser(config, runtime, http_delete=self._http_delete)
+
+        steps = self._select_steps(only)
+        collector.archive_previous_raw([s.command for s in steps if s.copy_run_results])
+
+        report = RunReport(project_name=config.project_name)
+        primary_exc: BaseException | None = None
+
+        try:
+            for step in steps:
+                outcome = pipeline.invoke(step)
+                logs.flush()
+                if step.collect_metrics and outcome.dbt_result is not None:
+                    collector.collect(step.command, outcome.dbt_result)
+                if step.copy_run_results:
+                    collector.copy_run_results(step.command)
+                report.outcomes.append(outcome)
+                status = "success" if outcome.success else "FAILED"
+                suffix = " (skipped)" if outcome.skipped else ""
+                print(f"[{config.project_name}] {outcome.command}: {status}{suffix}")
+                if not outcome.success:
+                    raise DbtStepError(f"[{config.project_name}] {outcome.command} failed{outcome.detail}")
+        except BaseException as exc:  # noqa: BLE001 — re-raised below after cleanup
+            primary_exc = exc
+
+        flush_error: MetricsWriteError | None = None
+        try:
+            report.metric_rows_written = collector.flush_to_delta(runtime)
+        except MetricsWriteError as exc:
+            flush_error = exc
+            print(f"[{config.project_name}] {exc}")
+        closer.close()
+
+        if primary_exc is not None:
+            raise primary_exc
+        if flush_error is not None:
+            raise flush_error
+        return report
+
+    # --- Internals ------------------------------------------------------------
+
+    def _prepare_environment(self) -> None:
+        if self._config.git_root:
+            os.environ["GIT_ROOT"] = self._config.git_root
+        os.environ["DBT_PROFILES_DIR"] = self._config.profiles_dir
+
+    def _select_steps(self, only: list[str] | None) -> list[StepConfig]:
+        if only is None:
+            return list(self._config.pipeline)
+        wanted = set(only)
+        return [s for s in self._config.pipeline if s.command in wanted]

--- a/projects/fabric/python/dbt-runner-lib/src/dbt_runner/runtime/__init__.py
+++ b/projects/fabric/python/dbt-runner-lib/src/dbt_runner/runtime/__init__.py
@@ -1,0 +1,8 @@
+"""Runtime domain: token / storage-option / OneLake-identity providers."""
+
+from dbt_runner.runtime.base import RuntimeProvider
+from dbt_runner.runtime.factory import make_runtime
+from dbt_runner.runtime.fabric import FabricRuntime
+from dbt_runner.runtime.local import LocalRuntime
+
+__all__ = ["RuntimeProvider", "LocalRuntime", "FabricRuntime", "make_runtime"]

--- a/projects/fabric/python/dbt-runner-lib/src/dbt_runner/runtime/base.py
+++ b/projects/fabric/python/dbt-runner-lib/src/dbt_runner/runtime/base.py
@@ -1,0 +1,21 @@
+"""The :class:`RuntimeProvider` protocol — source of tokens / storage options /
+OneLake identity for a run."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class RuntimeProvider(Protocol):
+    """Where tokens, Delta storage options, and OneLake identity come from."""
+
+    @property
+    def is_fabric(self) -> bool: ...
+
+    def get_token(self, audience: str) -> str: ...
+
+    def storage_options(self) -> dict[str, str] | None: ...
+
+    def onelake_context(self) -> tuple[str | None, str | None]:
+        """Return ``(workspace_id, lakehouse_id)`` for abfss path rewriting."""
+        ...

--- a/projects/fabric/python/dbt-runner-lib/src/dbt_runner/runtime/fabric.py
+++ b/projects/fabric/python/dbt-runner-lib/src/dbt_runner/runtime/fabric.py
@@ -1,0 +1,41 @@
+"""Fabric notebook runtime backed by ``notebookutils`` (imported lazily).
+
+``notebookutils`` ships only with the Fabric Spark / Python notebook runtime and
+is not pip-installable, so the import is deferred to first use — the library
+stays importable (and unit-testable) on a plain devbox.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dbt_runner.errors import FabricRuntimeUnavailableError
+
+
+class FabricRuntime:
+    """Brokered tokens + OneLake context via ``notebookutils``."""
+
+    is_fabric = True
+
+    @staticmethod
+    def _notebookutils() -> Any:
+        try:
+            import notebookutils  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise FabricRuntimeUnavailableError("runtime 'fabric' requires the Fabric notebook runtime ('notebookutils' is not installable via pip)") from exc
+        return notebookutils
+
+    def get_token(self, audience: str) -> str:
+        token = self._notebookutils().credentials.getToken(audience)
+        if not isinstance(token, str) or not token:
+            raise FabricRuntimeUnavailableError(f"notebookutils.credentials.getToken({audience!r}) returned {token!r}")
+        return token
+
+    def storage_options(self) -> dict[str, str] | None:
+        return {"bearer_token": self.get_token("storage"), "use_fabric_endpoint": "true"}
+
+    def onelake_context(self) -> tuple[str | None, str | None]:
+        ctx = self._notebookutils().runtime.context
+        workspace_id = ctx.get("defaultLakehouseWorkspaceId") or ctx.get("currentWorkspaceId")
+        lakehouse_id = ctx.get("defaultLakehouseId")
+        return workspace_id, lakehouse_id

--- a/projects/fabric/python/dbt-runner-lib/src/dbt_runner/runtime/factory.py
+++ b/projects/fabric/python/dbt-runner-lib/src/dbt_runner/runtime/factory.py
@@ -1,0 +1,12 @@
+"""Factory: build the :class:`RuntimeProvider` selected by ``runner.runtime``."""
+
+from __future__ import annotations
+
+from dbt_runner.config import RunnerConfig
+from dbt_runner.runtime.base import RuntimeProvider
+from dbt_runner.runtime.fabric import FabricRuntime
+from dbt_runner.runtime.local import LocalRuntime
+
+
+def make_runtime(config: RunnerConfig) -> RuntimeProvider:
+    return FabricRuntime() if config.is_fabric else LocalRuntime()

--- a/projects/fabric/python/dbt-runner-lib/src/dbt_runner/runtime/local.py
+++ b/projects/fabric/python/dbt-runner-lib/src/dbt_runner/runtime/local.py
@@ -1,0 +1,20 @@
+"""Devbox runtime: local filesystem, no brokered tokens."""
+
+from __future__ import annotations
+
+from dbt_runner.errors import FabricRuntimeUnavailableError
+
+
+class LocalRuntime:
+    """Local filesystem runtime — Delta writes go to disk, tokens are rejected."""
+
+    is_fabric = False
+
+    def get_token(self, audience: str) -> str:
+        raise FabricRuntimeUnavailableError(f"token for audience {audience!r} requires the Fabric notebook runtime; runtime is 'local'")
+
+    def storage_options(self) -> dict[str, str] | None:
+        return None
+
+    def onelake_context(self) -> tuple[str | None, str | None]:
+        return None, None

--- a/projects/fabric/python/dbt-runner-lib/src/dbt_runner/session/__init__.py
+++ b/projects/fabric/python/dbt-runner-lib/src/dbt_runner/session/__init__.py
@@ -1,0 +1,6 @@
+"""Session domain: Fabric Livy session close + helpers."""
+
+from dbt_runner.session.closer import HttpDelete, SessionCloser
+from dbt_runner.session.livy import build_livy_delete_url, resolve_env_var
+
+__all__ = ["SessionCloser", "HttpDelete", "build_livy_delete_url", "resolve_env_var"]

--- a/projects/fabric/python/dbt-runner-lib/src/dbt_runner/session/closer.py
+++ b/projects/fabric/python/dbt-runner-lib/src/dbt_runner/session/closer.py
@@ -1,0 +1,69 @@
+"""Close the Fabric Spark (Livy) session dbt opened.
+
+Only used when ``session.close`` is true (Fabric runs). The local Livy session is
+intentionally reused across runs via its ``session_id_file``. Never raises — a
+failed close is a warning, not a run failure.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Callable
+
+import yaml
+
+from dbt_runner.config import RunnerConfig
+from dbt_runner.runtime import RuntimeProvider
+from dbt_runner.session.livy import build_livy_delete_url, resolve_env_var
+
+# An HTTP DELETE: takes (url, headers), returns a response-like object.
+HttpDelete = Callable[[str, dict[str, str]], Any]
+
+
+def _default_http_delete(url: str, headers: dict[str, str]) -> Any:
+    import requests
+
+    return requests.delete(url, headers=headers)
+
+
+class SessionCloser:
+    """Closes the Livy session referenced by a project's profiles.yml target."""
+
+    def __init__(
+        self,
+        config: RunnerConfig,
+        runtime: RuntimeProvider,
+        *,
+        env: dict[str, str] | None = None,
+        http_delete: HttpDelete | None = None,
+    ) -> None:
+        self._config = config
+        self._runtime = runtime
+        self._env = env if env is not None else dict(os.environ)
+        self._http_delete = http_delete or _default_http_delete
+
+    def close(self) -> None:
+        """Close the session if configured. Never raises."""
+        if not self._config.session.close:
+            return
+        project = self._config.project_name
+        try:
+            profiles_path = f"{self._config.profiles_dir}/profiles.yml"
+            with open(profiles_path) as handle:
+                profiles = yaml.safe_load(handle)
+            profile_name = next(iter(profiles))
+            target = self._config.session.target or self._config.target
+            cfg = profiles[profile_name]["outputs"][target]
+
+            with open(cfg["session_id_file"]) as handle:
+                session_id = handle.read().strip()
+
+            workspace_id = self._config.session.workspace_id or resolve_env_var(cfg.get("workspaceid"), "FABRIC_WORKSPACE_ID", self._env)
+            lakehouse_id = self._config.session.lakehouse_id or resolve_env_var(cfg.get("lakehouseid"), "FABRIC_LAKEHOUSE_ID", self._env)
+
+            url = build_livy_delete_url(self._config.session.endpoint, workspace_id, lakehouse_id, session_id)
+            print(f"Deleting session {session_id}: {url}")
+            response = self._http_delete(url, {"Authorization": f"Bearer {self._runtime.get_token('pbi')}"})
+            print(f"Delete session {session_id}: {getattr(response, 'status_code', '?')} {getattr(response, 'reason', '')}")
+        except Exception as exc:
+            print(f"Warning: failed to close Livy session for {project}: {exc}")

--- a/projects/fabric/python/dbt-runner-lib/src/dbt_runner/session/livy.py
+++ b/projects/fabric/python/dbt-runner-lib/src/dbt_runner/session/livy.py
@@ -1,0 +1,25 @@
+"""Pure helpers for the Fabric Livy session API + dbt env_var resolution."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+_ENV_VAR_RE = re.compile(r"\{\{\s*env_var\s*\(\s*'[^']*'\s*,\s*'([^']*)'\s*\)\s*\}\}")
+
+
+def resolve_env_var(yaml_value: Any, env_key: str, env: dict[str, str]) -> Any:
+    """Return ``env[env_key]`` if set, else the default inside a dbt
+    ``{{ env_var('KEY', 'default') }}`` template string, else the value as-is."""
+    env_val = env.get(env_key)
+    if env_val:
+        return env_val
+    if isinstance(yaml_value, str):
+        match = _ENV_VAR_RE.search(yaml_value)
+        if match:
+            return match.group(1)
+    return yaml_value
+
+
+def build_livy_delete_url(endpoint: str, workspace_id: str, lakehouse_id: str, session_id: str) -> str:
+    return f"{endpoint.rstrip('/')}/workspaces/{workspace_id}/lakehouses/{lakehouse_id}/livyApi/versions/2023-12-01/sessions/{session_id}"

--- a/projects/fabric/python/dbt-runner-lib/tests/_helpers.py
+++ b/projects/fabric/python/dbt-runner-lib/tests/_helpers.py
@@ -1,0 +1,84 @@
+"""Shared test helpers: config payload factory + fake dbtRunner result objects."""
+
+from __future__ import annotations
+
+import copy
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any
+
+
+def runner_payload(**overrides: Any) -> dict[str, Any]:
+    """A minimal-but-complete valid ``runner`` payload; override any key."""
+    payload: dict[str, Any] = {
+        "project_name": "dbt-example",
+        "project_dir": "/tmp/projects/dbt-example",
+        "target": "local-local",
+        "runtime": "local",
+        "pipeline": [
+            {"command": "deps"},
+            {"command": "seed", "collect_metrics": True, "copy_run_results": True},
+            {"command": "build", "exclude": ["resource_type:seed"], "collect_metrics": True, "copy_run_results": True},
+        ],
+        "metrics": {
+            "enabled": True,
+            "delta_path": "/tmp/.temp/metrics/dbt_node_executions",
+            "raw_path": "/tmp/.temp/metrics/raw",
+        },
+    }
+    merged = copy.deepcopy(payload)
+    merged.update(overrides)
+    return merged
+
+
+# --- Fake dbtRunner result objects -------------------------------------------
+
+
+def fake_timing(name: str, started: datetime, completed: datetime) -> SimpleNamespace:
+    return SimpleNamespace(name=name, started_at=started, completed_at=completed)
+
+
+def fake_node(**kwargs: Any) -> SimpleNamespace:
+    base = dict(
+        unique_id="model.example.dim_customer",
+        resource_type="model",
+        package_name="example",
+        name="dim_customer",
+        alias="dim_customer",
+        database="db",
+        schema="dbt_example_dwh",
+        relation_name="`db`.`dbt_example_dwh`.`dim_customer`",
+        original_file_path="models/marts/dim_customer.sql",
+        config=SimpleNamespace(materialized="table", to_dict=lambda: {"materialized": "table"}),
+        tags=["nightly"],
+        depends_on=SimpleNamespace(nodes=["model.example.stg_customer"]),
+        test_metadata=None,
+    )
+    base.update(kwargs)
+    return SimpleNamespace(**base)
+
+
+def fake_node_result(*, status: str = "success", rows_affected: int = 3, with_timing: bool = True) -> SimpleNamespace:
+    start = datetime(2026, 6, 17, 10, 0, 0, tzinfo=timezone.utc)
+    mid = datetime(2026, 6, 17, 10, 0, 1, tzinfo=timezone.utc)
+    end = datetime(2026, 6, 17, 10, 0, 3, tzinfo=timezone.utc)
+    timing = [fake_timing("compile", start, mid), fake_timing("execute", mid, end)] if with_timing else []
+    return SimpleNamespace(
+        node=fake_node(),
+        timing=timing,
+        adapter_response={"rows_affected": rows_affected, "_message": "OK"},
+        failures=None,
+        execution_time=3.0,
+        thread_id="Thread-1",
+        status=status,
+        message="OK",
+        to_dict=lambda: {"unique_id": "model.example.dim_customer", "status": status},
+    )
+
+
+def fake_invoke_result(*, success: bool = True, node_results: list[Any] | None = None, generated_at: datetime | None = None, exception: Any = None) -> SimpleNamespace:
+    """Mimic the object returned by ``dbtRunner().invoke(...)``."""
+    inner = None
+    if node_results is not None:
+        inner = SimpleNamespace(results=node_results, generated_at=generated_at or datetime(2026, 6, 17, 10, 0, 3, tzinfo=timezone.utc))
+    return SimpleNamespace(success=success, result=inner, exception=exception)

--- a/projects/fabric/python/dbt-runner-lib/tests/conftest.py
+++ b/projects/fabric/python/dbt-runner-lib/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Pytest configuration for `dbt-runner-lib` unit tests."""
+
+import sys
+from pathlib import Path
+
+# Make the in-tree src/ importable even before an editable install.
+_SRC = Path(__file__).resolve().parents[1] / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))

--- a/projects/fabric/python/dbt-runner-lib/tests/test_cli.py
+++ b/projects/fabric/python/dbt-runner-lib/tests/test_cli.py
@@ -1,0 +1,49 @@
+"""Tests for `dbt_runner.__main__` (the CLI)."""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from dbt_runner.__main__ import main
+
+
+def _b64(yaml_str: str) -> str:
+    return base64.b64encode(yaml_str.encode()).decode()
+
+
+# A dbt-free pipeline (single shell step) so the CLI exercises the real
+# load -> DbtRunner -> run path without needing dbt-core installed.
+_SHELL_ONLY = """
+runner:
+  project_name: dbt-cli-test
+  project_dir: /tmp
+  target: local-local
+  runtime: local
+  pipeline:
+    - command: shell
+      argv: ["true"]
+  metrics:
+    enabled: false
+"""
+
+
+class TestCli:
+    def test_run_shell_only_succeeds(self, capsys):
+        assert main(["run", "--config-base64", _b64(_SHELL_ONLY)]) == 0
+
+    def test_run_from_yaml(self):
+        assert main(["run", "--config-yaml", _SHELL_ONLY]) == 0
+
+    def test_run_invalid_base64_returns_1(self, capsys):
+        assert main(["run", "--config-base64", "!!!notb64!!!"]) == 1
+        assert "ERROR" in capsys.readouterr().err
+
+    def test_show_default_prints_template(self, capsys):
+        assert main(["show-default"]) == 0
+        assert "runner" in capsys.readouterr().out
+
+    def test_missing_subcommand_errors(self):
+        with pytest.raises(SystemExit):
+            main([])

--- a/projects/fabric/python/dbt-runner-lib/tests/test_config.py
+++ b/projects/fabric/python/dbt-runner-lib/tests/test_config.py
@@ -1,0 +1,205 @@
+"""Tests for `dbt_runner.config`."""
+
+from __future__ import annotations
+
+import base64
+import textwrap
+
+import pytest
+
+from _helpers import runner_payload
+from dbt_runner.config import (
+    RUNTIME_FABRIC,
+    RUNTIME_LOCAL,
+    RunnerConfig,
+    StepConfig,
+    decode_base64,
+    load_default_template,
+    load_runner_config,
+)
+from dbt_runner.errors import RunnerConfigError
+
+
+class TestRunnerConfigBasics:
+    def test_minimal_valid(self):
+        cfg = RunnerConfig.from_mapping(runner_payload())
+        assert cfg.project_name == "dbt-example"
+        assert cfg.profiles_dir == cfg.project_dir  # defaulted
+        assert cfg.runtime == RUNTIME_LOCAL
+        assert cfg.is_fabric is False
+        assert len(cfg.pipeline) == 3
+        assert cfg.metrics.partition_by == ("project", "event_year_month")
+
+    def test_profiles_dir_explicit(self):
+        cfg = RunnerConfig.from_mapping(runner_payload(profiles_dir="/somewhere/else"))
+        assert cfg.profiles_dir == "/somewhere/else"
+
+    def test_runtime_fabric_case_insensitive(self):
+        cfg = RunnerConfig.from_mapping(runner_payload(runtime="Fabric"))
+        assert cfg.runtime == RUNTIME_FABRIC
+        assert cfg.is_fabric is True
+
+    def test_vars_passthrough(self):
+        cfg = RunnerConfig.from_mapping(runner_payload(vars={"region_filter": ["*"], "lookback_days": 30}))
+        assert cfg.vars == {"region_filter": ["*"], "lookback_days": 30}
+
+
+class TestRunnerConfigValidation:
+    @pytest.mark.parametrize("missing", ["project_name", "project_dir", "target"])
+    def test_required_fields(self, missing):
+        payload = runner_payload()
+        del payload[missing]
+        with pytest.raises(RunnerConfigError, match=missing):
+            RunnerConfig.from_mapping(payload)
+
+    def test_pipeline_required_non_empty(self):
+        with pytest.raises(RunnerConfigError, match="pipeline"):
+            RunnerConfig.from_mapping(runner_payload(pipeline=[]))
+
+    def test_unknown_runtime_rejected(self):
+        with pytest.raises(RunnerConfigError, match="runtime"):
+            RunnerConfig.from_mapping(runner_payload(runtime="kubernetes"))
+
+    def test_vars_must_be_mapping(self):
+        with pytest.raises(RunnerConfigError, match="vars"):
+            RunnerConfig.from_mapping(runner_payload(vars=["not", "a", "map"]))
+
+    def test_collect_metrics_requires_metrics_enabled(self):
+        payload = runner_payload(metrics={"enabled": False})
+        with pytest.raises(RunnerConfigError, match="collect_metrics"):
+            RunnerConfig.from_mapping(payload)
+
+    def test_metrics_delta_path_required_when_enabled(self):
+        payload = runner_payload(
+            pipeline=[{"command": "build"}],
+            metrics={"enabled": True, "raw_path": "/tmp/raw"},
+        )
+        with pytest.raises(RunnerConfigError, match="delta_path"):
+            RunnerConfig.from_mapping(payload)
+
+
+class TestStepConfig:
+    def test_run_operation_requires_macro(self):
+        with pytest.raises(RunnerConfigError, match="macro"):
+            StepConfig.from_mapping({"command": "run-operation"}, index=0)
+
+    def test_run_operation_with_macro_and_if_exists(self):
+        step = StepConfig.from_mapping({"command": "run-operation", "macro": "cleanup", "if_macro_exists": True}, index=0)
+        assert step.macro == "cleanup"
+        assert step.if_macro_exists is True
+
+    def test_macro_only_for_run_operation(self):
+        with pytest.raises(RunnerConfigError, match="run-operation"):
+            StepConfig.from_mapping({"command": "build", "macro": "x"}, index=0)
+
+    def test_shell_requires_argv(self):
+        with pytest.raises(RunnerConfigError, match="argv"):
+            StepConfig.from_mapping({"command": "shell"}, index=0)
+
+    def test_shell_with_argv(self):
+        step = StepConfig.from_mapping({"command": "shell", "argv": ["echo", "hi"]}, index=0)
+        assert step.argv == ("echo", "hi")
+
+    def test_argv_only_for_shell(self):
+        with pytest.raises(RunnerConfigError, match="shell"):
+            StepConfig.from_mapping({"command": "build", "argv": ["x"]}, index=0)
+
+    def test_full_refresh_rejected_for_test(self):
+        with pytest.raises(RunnerConfigError, match="full_refresh"):
+            StepConfig.from_mapping({"command": "test", "full_refresh": True}, index=0)
+
+    def test_selection_rejected_for_deps(self):
+        with pytest.raises(RunnerConfigError, match="selection"):
+            StepConfig.from_mapping({"command": "deps", "select": ["x"]}, index=0)
+
+    def test_if_macro_exists_only_for_run_operation(self):
+        with pytest.raises(RunnerConfigError, match="if_macro_exists"):
+            StepConfig.from_mapping({"command": "build", "if_macro_exists": True}, index=0)
+
+    def test_unknown_command_rejected(self):
+        with pytest.raises(RunnerConfigError, match="unsupported"):
+            StepConfig.from_mapping({"command": "frobnicate"}, index=2)
+
+    def test_accepts_vars_property(self):
+        assert StepConfig.from_mapping({"command": "build"}, index=0).accepts_vars is True
+        assert StepConfig.from_mapping({"command": "deps"}, index=0).accepts_vars is False
+
+    def test_exclude_string_shorthand(self):
+        step = StepConfig.from_mapping({"command": "build", "exclude": "resource_type:seed"}, index=0)
+        assert step.exclude == ("resource_type:seed",)
+
+
+class TestLoadRunnerConfig:
+    def test_from_config_dict_runner_wrapped(self):
+        cfg = load_runner_config(config={"runner": runner_payload()})
+        assert cfg.project_name == "dbt-example"
+
+    def test_from_config_dict_bare(self):
+        cfg = load_runner_config(config=runner_payload())
+        assert cfg.project_name == "dbt-example"
+
+    def test_from_yaml(self):
+        yaml_str = textwrap.dedent("""
+            runner:
+              project_name: dbt-y
+              project_dir: /tmp/y
+              target: local-local
+              pipeline:
+                - { command: build }
+              metrics: { enabled: false }
+            """)
+        cfg = load_runner_config(config_yaml=yaml_str)
+        assert cfg.project_name == "dbt-y"
+        assert cfg.metrics.enabled is False
+
+    def test_from_base64(self):
+        yaml_str = "runner:\n  project_name: b\n  project_dir: /tmp/b\n  target: t\n  pipeline:\n    - {command: build}\n  metrics: {enabled: false}\n"
+        b64 = base64.b64encode(yaml_str.encode()).decode()
+        cfg = load_runner_config(config_base64=b64)
+        assert cfg.project_name == "b"
+
+    def test_from_path(self, tmp_path):
+        path = tmp_path / "runner.yaml"
+        path.write_text("runner:\n  project_name: p\n  project_dir: /tmp/p\n  target: t\n  pipeline:\n    - {command: deps}\n  metrics: {enabled: false}\n")
+        cfg = load_runner_config(config_path=str(path))
+        assert cfg.project_name == "p"
+
+    def test_rejects_zero_sources(self):
+        with pytest.raises(RunnerConfigError, match="no configuration supplied"):
+            load_runner_config()
+
+    def test_rejects_multiple_sources(self):
+        with pytest.raises(RunnerConfigError, match="mutually exclusive"):
+            load_runner_config(config=runner_payload(), config_yaml="runner: {}")
+
+    def test_yaml_without_runner_key_rejected(self):
+        with pytest.raises(RunnerConfigError, match="runner"):
+            load_runner_config(config_yaml="other:\n  x: 1\n")
+
+    def test_missing_file_rejected(self, tmp_path):
+        with pytest.raises(RunnerConfigError, match="does not exist"):
+            load_runner_config(config_path=str(tmp_path / "nope.yaml"))
+
+    def test_yaml_not_mapping_rejected(self):
+        with pytest.raises(RunnerConfigError, match="mapping"):
+            load_runner_config(config_yaml="just-a-scalar")
+
+
+class TestDecodeBase64:
+    def test_roundtrip(self):
+        assert decode_base64(base64.b64encode(b"hello: world").decode()) == "hello: world"
+
+    def test_invalid_base64_rejected(self):
+        with pytest.raises(RunnerConfigError, match="valid base64"):
+            decode_base64("!!!not base64!!!")
+
+    def test_empty_rejected(self):
+        with pytest.raises(RunnerConfigError, match="non-empty"):
+            decode_base64("")
+
+
+class TestDefaultTemplate:
+    def test_template_parses_to_runner_block(self):
+        template = load_default_template()
+        assert "runner" in template
+        assert template["runner"]["project_name"]

--- a/projects/fabric/python/dbt-runner-lib/tests/test_delta_sink.py
+++ b/projects/fabric/python/dbt-runner-lib/tests/test_delta_sink.py
@@ -1,0 +1,79 @@
+"""Tests for `dbt_runner.metrics.delta_sink`."""
+
+from __future__ import annotations
+
+import pytest
+
+from dbt_runner.errors import MetricsWriteError
+from dbt_runner.metrics.delta_sink import DeltaMetricsSink, resolve_delta_target
+from dbt_runner.runtime import LocalRuntime
+
+
+class _FakeFabricRuntime:
+    is_fabric = True
+
+    def __init__(self, ws=None, lh=None):
+        self._ws = ws
+        self._lh = lh
+
+    def get_token(self, audience):
+        return "tok"
+
+    def storage_options(self):
+        return {"bearer_token": "tok", "use_fabric_endpoint": "true"}
+
+    def onelake_context(self):
+        return self._ws, self._lh
+
+
+class TestResolveDeltaTarget:
+    def test_local_path_returns_no_storage_options(self, tmp_path):
+        target = str(tmp_path / "metrics" / "dbt_node_executions")
+        uri, opts = resolve_delta_target(target, LocalRuntime())
+        assert uri == target
+        assert opts is None
+        assert (tmp_path / "metrics").is_dir()  # parent created eagerly
+
+    def test_abfss_passthrough_with_storage_options(self):
+        rt = _FakeFabricRuntime()
+        uri, opts = resolve_delta_target("abfss://ws@onelake.dfs.fabric.microsoft.com/lh/Tables/m", rt)
+        assert uri == "abfss://ws@onelake.dfs.fabric.microsoft.com/lh/Tables/m"
+        assert opts == {"bearer_token": "tok", "use_fabric_endpoint": "true"}
+
+    def test_onelake_fuse_path_rewritten(self):
+        rt = _FakeFabricRuntime(ws="ws-1", lh="lh-1")
+        uri, opts = resolve_delta_target("/lakehouse/default/Files/raw/dbt/dbt_node_executions", rt)
+        assert uri == "abfss://ws-1@onelake.dfs.fabric.microsoft.com/lh-1/Files/raw/dbt/dbt_node_executions"
+        assert opts == {"bearer_token": "tok", "use_fabric_endpoint": "true"}
+
+    def test_onelake_fuse_path_without_context_raises(self):
+        rt = _FakeFabricRuntime(ws=None, lh=None)
+        with pytest.raises(MetricsWriteError, match="workspace/lakehouse id unavailable"):
+            resolve_delta_target("/lakehouse/default/Files/raw/m", rt)
+
+
+class TestDeltaMetricsSink:
+    def test_write_returns_count_and_uri(self, tmp_path):
+        from datetime import datetime, timezone
+
+        from deltalake import DeltaTable
+
+        from _helpers import fake_node_result, runner_payload
+        from dbt_runner.config import RunnerConfig
+        from dbt_runner.metrics.normalize import normalize_node_result
+
+        delta_path = str(tmp_path / "delta" / "dbt_node_executions")
+        cfg = RunnerConfig.from_mapping(runner_payload(metrics={"enabled": True, "delta_path": delta_path}))
+        row = normalize_node_result("dbt-example", "build", fake_node_result(), datetime(2026, 6, 17, tzinfo=timezone.utc), "inv", dbt_version="1.9", invocation_started_at=datetime(2026, 6, 17))
+        written, uri = DeltaMetricsSink(cfg).write([row], LocalRuntime())
+        assert written == 1
+        assert uri == delta_path
+        assert DeltaTable(delta_path).to_pyarrow_table().num_rows == 1
+
+    def test_write_without_delta_path_raises(self):
+        from _helpers import runner_payload
+        from dbt_runner.config import RunnerConfig
+
+        cfg = RunnerConfig.from_mapping(runner_payload(pipeline=[{"command": "build"}], metrics={"enabled": False}))
+        with pytest.raises(MetricsWriteError, match="delta_path is not set"):
+            DeltaMetricsSink(cfg).write([{"project": "x"}], LocalRuntime())

--- a/projects/fabric/python/dbt-runner-lib/tests/test_logs.py
+++ b/projects/fabric/python/dbt-runner-lib/tests/test_logs.py
@@ -1,0 +1,72 @@
+"""Tests for `dbt_runner.logs`."""
+
+from __future__ import annotations
+
+import os
+
+from _helpers import runner_payload
+from dbt_runner.config import RunnerConfig
+from dbt_runner.logs import LogManager, flush_dbt_logs, prepare_log_path
+
+
+def _cfg(tmp_path, **logging_overrides):
+    logging = {"log_path": str(tmp_path / "logs")}
+    logging.update(logging_overrides)
+    return RunnerConfig.from_mapping(runner_payload(logging=logging))
+
+
+class TestPrepareLogPath:
+    def test_creates_dir_and_sets_env(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("DBT_LOG_PATH", raising=False)
+        cfg = _cfg(tmp_path)
+        dbt_log_file = prepare_log_path(cfg)
+        assert dbt_log_file == str(tmp_path / "logs" / "dbt.log")
+        assert (tmp_path / "logs").is_dir()
+        assert os.environ["DBT_LOG_PATH"] == str(tmp_path / "logs")
+
+    def test_archives_previous_log(self, tmp_path):
+        logs = tmp_path / "logs"
+        logs.mkdir()
+        (logs / "dbt.log").write_text("old run")
+        prepare_log_path(_cfg(tmp_path))
+        assert not (logs / "dbt.log").exists()
+        assert any(p.name.startswith("dbt-archived-at-") for p in logs.iterdir())
+
+    def test_archive_disabled_keeps_log(self, tmp_path):
+        logs = tmp_path / "logs"
+        logs.mkdir()
+        (logs / "dbt.log").write_text("keep me")
+        prepare_log_path(_cfg(tmp_path, archive_previous=False))
+        assert (logs / "dbt.log").read_text() == "keep me"
+
+    def test_no_log_path_returns_none(self):
+        cfg = RunnerConfig.from_mapping(runner_payload())
+        assert prepare_log_path(cfg) is None
+
+
+class TestFlushDbtLogs:
+    def test_none_is_safe(self):
+        flush_dbt_logs(None)  # must not raise
+
+    def test_missing_file_is_safe(self, tmp_path):
+        flush_dbt_logs(str(tmp_path / "nope.log"))  # must not raise
+
+    def test_existing_file_is_fsynced(self, tmp_path):
+        log = tmp_path / "dbt.log"
+        log.write_text("line")
+        flush_dbt_logs(str(log))  # must not raise
+
+
+class TestLogManager:
+    def test_prepare_exposes_dbt_log_file(self, tmp_path):
+        mgr = LogManager(_cfg(tmp_path))
+        assert mgr.dbt_log_file is None
+        produced = mgr.prepare()
+        assert produced == mgr.dbt_log_file == str(tmp_path / "logs" / "dbt.log")
+        mgr.flush()  # must not raise
+
+    def test_prepare_without_log_path(self):
+        mgr = LogManager(RunnerConfig.from_mapping(runner_payload()))
+        assert mgr.prepare() is None
+        assert mgr.dbt_log_file is None
+        mgr.flush()  # must not raise

--- a/projects/fabric/python/dbt-runner-lib/tests/test_metrics.py
+++ b/projects/fabric/python/dbt-runner-lib/tests/test_metrics.py
@@ -1,0 +1,128 @@
+"""Tests for `dbt_runner.metrics` — normalization, schema parity, Delta flush."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import pyarrow as pa
+import pytest
+
+from _helpers import fake_invoke_result, fake_node_result, runner_payload
+from dbt_runner.config import RunnerConfig
+from dbt_runner.metrics import PA_SCHEMA, MetricsCollector, normalize_node_result
+from dbt_runner.errors import MetricsWriteError
+
+_NOW = datetime(2026, 6, 17, 10, 0, 3, tzinfo=timezone.utc)
+_STARTED = datetime(2026, 6, 17, 9, 0, 0)
+
+
+class TestNormalizeNodeResult:
+    def test_row_is_schema_compatible(self):
+        row = normalize_node_result("dbt-example", "build", fake_node_result(), _NOW, "inv-1", dbt_version="1.9.0", invocation_started_at=_STARTED)
+        # Building a table with PA_SCHEMA proves every field type matches.
+        table = pa.Table.from_pylist([row], schema=PA_SCHEMA)
+        assert table.num_rows == 1
+
+    def test_core_fields(self):
+        row = normalize_node_result("dbt-example", "build", fake_node_result(rows_affected=7), _NOW, "inv-1", dbt_version="1.9.0", invocation_started_at=_STARTED)
+        assert row["project"] == "dbt-example"
+        assert row["command"] == "build"
+        assert row["invocation_id"] == "inv-1"
+        assert row["dbt_version"] == "1.9.0"
+        assert row["unique_id"] == "model.example.dim_customer"
+        assert row["rows_affected"] == 7
+        assert row["materialized"] == "table"
+        assert row["compile_time"] == 1.0
+        assert row["execute_time"] == 2.0
+        assert row["event_year_month"] == "202606"
+        assert row["tags"] == ["nightly"]
+        assert row["depends_on_nodes"] == ["model.example.stg_customer"]
+        assert json.loads(row["adapter_response_json"])["rows_affected"] == 7
+
+    def test_handles_missing_timing(self):
+        row = normalize_node_result("p", "seed", fake_node_result(with_timing=False), _NOW, None, dbt_version="x", invocation_started_at=_STARTED)
+        assert row["compile_time"] is None
+        assert row["execute_time"] is None
+        # Falls back to generated_at for the partition.
+        assert row["event_year_month"] == "202606"
+
+
+def _cfg(tmp_path, **metrics_overrides):
+    metrics = {"enabled": True, "delta_path": str(tmp_path / "delta" / "dbt_node_executions"), "raw_path": str(tmp_path / "raw")}
+    metrics.update(metrics_overrides)
+    return RunnerConfig.from_mapping(runner_payload(metrics=metrics))
+
+
+class _Local:
+    is_fabric = False
+
+    def get_token(self, audience):
+        raise AssertionError("local runtime should not need a token")
+
+    def storage_options(self):
+        return None
+
+    def onelake_context(self):
+        return None, None
+
+
+class TestMetricsCollectorFlush:
+    def test_collect_and_flush_writes_delta(self, tmp_path):
+        from deltalake import DeltaTable
+
+        cfg = _cfg(tmp_path)
+        collector = MetricsCollector(cfg)
+        result = fake_invoke_result(success=True, node_results=[fake_node_result(), fake_node_result()])
+        collector.collect("build", result)
+        assert len(collector.buffer) == 2
+
+        written = collector.flush_to_delta(_Local())
+        assert written == 2
+
+        dt = DeltaTable(str(tmp_path / "delta" / "dbt_node_executions"))
+        table = dt.to_pyarrow_table()
+        assert table.num_rows == 2
+        assert set(table.column("project").to_pylist()) == {"dbt-example"}
+        # Partitioned by project + event_year_month.
+        assert set(dt.metadata().partition_columns) == {"project", "event_year_month"}
+
+    def test_flush_empty_buffer_writes_nothing(self, tmp_path):
+        cfg = _cfg(tmp_path)
+        assert MetricsCollector(cfg).flush_to_delta(_Local()) == 0
+
+    def test_collect_is_noop_for_resultless_command(self, tmp_path):
+        cfg = _cfg(tmp_path)
+        collector = MetricsCollector(cfg)
+        collector.collect("deps", fake_invoke_result(success=True, node_results=None))
+        assert collector.buffer == []
+
+    def test_disabled_metrics_flush_returns_zero(self, tmp_path):
+        cfg = RunnerConfig.from_mapping(runner_payload(pipeline=[{"command": "build"}], metrics={"enabled": False}))
+        collector = MetricsCollector(cfg)
+        assert collector.flush_to_delta(_Local()) == 0
+
+    def test_copy_run_results(self, tmp_path):
+        # copy_run_results reads <project_dir>/target/run_results.json
+        proj_target = tmp_path / "target"
+        (proj_target).mkdir(parents=True)
+        (proj_target / "run_results.json").write_text('{"results": []}')
+        cfg = RunnerConfig.from_mapping(
+            runner_payload(
+                project_dir=str(tmp_path),
+                metrics={"enabled": True, "delta_path": str(tmp_path / "d"), "raw_path": str(tmp_path / "raw")},
+            )
+        )
+        collector = MetricsCollector(cfg)
+        collector.copy_run_results("build")
+        assert (tmp_path / "raw" / "run_results-build.json").is_file()
+
+    def test_archive_previous_raw(self, tmp_path):
+        raw = tmp_path / "raw"
+        raw.mkdir()
+        (raw / "run_results-build.json").write_text("{}")
+        cfg = _cfg(tmp_path)
+        MetricsCollector(cfg).archive_previous_raw(["build"])
+        # Original renamed away; an archived copy exists.
+        assert not (raw / "run_results-build.json").exists()
+        assert any(p.name.startswith("run_results-build-archived-at-") for p in raw.iterdir())

--- a/projects/fabric/python/dbt-runner-lib/tests/test_pipeline.py
+++ b/projects/fabric/python/dbt-runner-lib/tests/test_pipeline.py
@@ -1,0 +1,166 @@
+"""Tests for `dbt_runner.pipeline`."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from _helpers import fake_invoke_result, runner_payload
+from dbt_runner.config import RunnerConfig, StepConfig
+from dbt_runner.pipeline import DbtPipeline, build_dbt_args, macro_exists
+from dbt_runner.pipeline.args import DbtArgsBuilder
+from dbt_runner.pipeline.macros import MacroResolver
+
+
+def _cfg(**overrides):
+    return RunnerConfig.from_mapping(runner_payload(**overrides))
+
+
+class TestBuildDbtArgs:
+    def test_deps_minimal(self):
+        cfg = _cfg()
+        args = build_dbt_args(StepConfig.from_mapping({"command": "deps"}, index=0), cfg)
+        assert args == ["deps", "--project-dir", cfg.project_dir, "--profiles-dir", cfg.profiles_dir, "--target", "local-local"]
+
+    def test_build_with_exclude_and_full_refresh(self):
+        cfg = _cfg()
+        step = StepConfig.from_mapping({"command": "build", "exclude": ["resource_type:seed"], "full_refresh": True}, index=0)
+        args = build_dbt_args(step, cfg)
+        assert "--exclude" in args and "resource_type:seed" in args
+        assert "--full-refresh" in args
+
+    def test_vars_injected_when_present(self):
+        cfg = _cfg(vars={"region_filter": ["*"]})
+        args = build_dbt_args(StepConfig.from_mapping({"command": "build"}, index=0), cfg)
+        assert "--vars" in args
+        assert args[args.index("--vars") + 1] == '{"region_filter": ["*"]}'
+
+    def test_vars_not_injected_when_empty(self):
+        cfg = _cfg()
+        args = build_dbt_args(StepConfig.from_mapping({"command": "build"}, index=0), cfg)
+        assert "--vars" not in args
+
+    def test_vars_not_injected_for_deps(self):
+        cfg = _cfg(vars={"x": 1})
+        args = build_dbt_args(StepConfig.from_mapping({"command": "deps"}, index=0), cfg)
+        assert "--vars" not in args
+
+    def test_docs_generate_maps_to_two_tokens(self):
+        cfg = _cfg()
+        args = build_dbt_args(StepConfig.from_mapping({"command": "docs-generate"}, index=0), cfg)
+        assert args[:2] == ["docs", "generate"]
+
+    def test_run_operation_includes_macro_and_args(self):
+        cfg = _cfg()
+        step = StepConfig.from_mapping({"command": "run-operation", "macro": "my_macro", "macro_args": {"k": "v"}}, index=0)
+        args = build_dbt_args(step, cfg)
+        assert args[:2] == ["run-operation", "my_macro"]
+        assert "--args" in args
+        assert args[args.index("--args") + 1] == '{"k": "v"}'
+
+    def test_select_joined(self):
+        cfg = _cfg()
+        step = StepConfig.from_mapping({"command": "build", "select": ["dim_customer+", "fct_sales"]}, index=0)
+        args = build_dbt_args(step, cfg)
+        assert args[args.index("--select") + 1] == "dim_customer+ fct_sales"
+
+
+class TestMacroExists:
+    def test_finds_macro(self, tmp_path):
+        macros = tmp_path / "macros"
+        macros.mkdir()
+        (macros / "cleanup.sql").write_text("{% macro cleanup_dbt_tmp_relations() %}{% endmacro %}")
+        assert macro_exists(str(tmp_path), "cleanup_dbt_tmp_relations") is True
+
+    def test_absent_macro(self, tmp_path):
+        (tmp_path / "macros").mkdir()
+        assert macro_exists(str(tmp_path), "cleanup_dbt_tmp_relations") is False
+
+    def test_no_macros_dir(self, tmp_path):
+        assert macro_exists(str(tmp_path), "anything") is False
+
+
+class TestArgsBuilderAndMacroResolverClasses:
+    def test_args_builder_build(self):
+        cfg = _cfg(vars={"region_filter": ["*"]})
+        args = DbtArgsBuilder(cfg).build(StepConfig.from_mapping({"command": "build"}, index=0))
+        assert args[0] == "build"
+        assert "--vars" in args
+        # The functional shim delegates to the class — identical output.
+        assert args == build_dbt_args(StepConfig.from_mapping({"command": "build"}, index=0), cfg)
+
+    def test_macro_resolver_exists(self, tmp_path):
+        (tmp_path / "macros").mkdir()
+        (tmp_path / "macros" / "m.sql").write_text("{% macro foo() %}{% endmacro %}")
+        resolver = MacroResolver(str(tmp_path))
+        assert resolver.exists("foo") is True
+        assert resolver.exists("bar") is False
+
+
+class TestDbtPipelineInvoke:
+    def test_dbt_step_success(self):
+        captured = {}
+
+        def fake_invoke(args):
+            captured["args"] = args
+            return fake_invoke_result(success=True)
+
+        pipe = DbtPipeline(_cfg(), dbt_invoke=fake_invoke)
+        outcome = pipe.invoke(StepConfig.from_mapping({"command": "deps"}, index=0))
+        assert outcome.success is True
+        assert outcome.command == "deps"
+        assert captured["args"][0] == "deps"
+
+    def test_dbt_step_failure_detail(self):
+        def fake_invoke(args):
+            return fake_invoke_result(success=False, exception=RuntimeError("boom"))
+
+        pipe = DbtPipeline(_cfg(), dbt_invoke=fake_invoke)
+        outcome = pipe.invoke(StepConfig.from_mapping({"command": "build"}, index=0))
+        assert outcome.success is False
+        assert "boom" in outcome.detail
+
+    def test_run_operation_skipped_when_macro_missing(self, tmp_path):
+        cfg = _cfg(project_dir=str(tmp_path))
+        called = {"n": 0}
+
+        def fake_invoke(args):
+            called["n"] += 1
+            return fake_invoke_result(success=True)
+
+        pipe = DbtPipeline(cfg, dbt_invoke=fake_invoke)
+        step = StepConfig.from_mapping({"command": "run-operation", "macro": "cleanup", "if_macro_exists": True}, index=0)
+        outcome = pipe.invoke(step)
+        assert outcome.skipped is True
+        assert outcome.success is True
+        assert called["n"] == 0  # dbt never invoked
+
+    def test_run_operation_runs_when_macro_present(self, tmp_path):
+        macros = tmp_path / "macros"
+        macros.mkdir()
+        (macros / "c.sql").write_text("{% macro cleanup() %}{% endmacro %}")
+        cfg = _cfg(project_dir=str(tmp_path))
+        pipe = DbtPipeline(cfg, dbt_invoke=lambda args: fake_invoke_result(success=True))
+        step = StepConfig.from_mapping({"command": "run-operation", "macro": "cleanup", "if_macro_exists": True}, index=0)
+        outcome = pipe.invoke(step)
+        assert outcome.skipped is False
+        assert outcome.success is True
+
+    def test_shell_step_success(self):
+        captured = {}
+
+        def fake_shell(argv, cwd):
+            captured["argv"] = argv
+            captured["cwd"] = cwd
+            return SimpleNamespace(returncode=0)
+
+        cfg = _cfg()
+        pipe = DbtPipeline(cfg, shell_invoke=fake_shell)
+        outcome = pipe.invoke(StepConfig.from_mapping({"command": "shell", "argv": ["echo", "hi"]}, index=0))
+        assert outcome.success is True
+        assert captured == {"argv": ["echo", "hi"], "cwd": cfg.project_dir}
+
+    def test_shell_step_failure(self):
+        pipe = DbtPipeline(_cfg(), shell_invoke=lambda argv, cwd: SimpleNamespace(returncode=2))
+        outcome = pipe.invoke(StepConfig.from_mapping({"command": "shell", "argv": ["false"]}, index=0))
+        assert outcome.success is False
+        assert "exit code: 2" in outcome.detail

--- a/projects/fabric/python/dbt-runner-lib/tests/test_runner.py
+++ b/projects/fabric/python/dbt-runner-lib/tests/test_runner.py
@@ -1,0 +1,140 @@
+"""Tests for `dbt_runner.runner` — end-to-end orchestration with mocked dbt."""
+
+from __future__ import annotations
+
+import pytest
+
+from _helpers import fake_invoke_result, fake_node_result, runner_payload
+from dbt_runner.config import RunnerConfig
+from dbt_runner.errors import DbtStepError
+from dbt_runner.runner import DbtRunner
+
+
+class _Local:
+    is_fabric = False
+
+    def get_token(self, audience):
+        raise AssertionError("no token locally")
+
+    def storage_options(self):
+        return None
+
+    def onelake_context(self):
+        return None, None
+
+
+def _make_config(tmp_path, **overrides):
+    project_dir = tmp_path / "project"
+    (project_dir / "target").mkdir(parents=True)
+    (project_dir / "target" / "run_results.json").write_text('{"results": []}')
+    base = runner_payload(
+        project_dir=str(project_dir),
+        pipeline=[
+            {"command": "deps"},
+            {"command": "seed", "collect_metrics": True, "copy_run_results": True},
+            {"command": "build", "exclude": ["resource_type:seed"], "collect_metrics": True, "copy_run_results": True},
+        ],
+        metrics={"enabled": True, "delta_path": str(tmp_path / "delta" / "dbt_node_executions"), "raw_path": str(tmp_path / "raw")},
+    )
+    base.update(overrides)
+    return RunnerConfig.from_mapping(base)
+
+
+def _invoker_with_nodes():
+    def fake_invoke(args):
+        command = args[0]
+        if command in ("seed", "build"):
+            return fake_invoke_result(success=True, node_results=[fake_node_result()])
+        return fake_invoke_result(success=True, node_results=None)
+
+    return fake_invoke
+
+
+class TestRunSuccess:
+    def test_full_pipeline_writes_metrics_and_copies_run_results(self, tmp_path):
+        from deltalake import DeltaTable
+
+        cfg = _make_config(tmp_path)
+        runner = DbtRunner(cfg, dbt_invoke=_invoker_with_nodes(), runtime=_Local())
+        report = runner.run()
+
+        assert report.success is True
+        assert [o.command for o in report.outcomes] == ["deps", "seed", "build"]
+        # seed + build each contributed one node row.
+        assert report.metric_rows_written == 2
+
+        dt = DeltaTable(str(tmp_path / "delta" / "dbt_node_executions"))
+        assert dt.to_pyarrow_table().num_rows == 2
+
+        # run_results copied per metric-bearing command.
+        assert (tmp_path / "raw" / "run_results-seed.json").is_file()
+        assert (tmp_path / "raw" / "run_results-build.json").is_file()
+
+    def test_only_filter_runs_subset(self, tmp_path):
+        cfg = _make_config(tmp_path)
+        runner = DbtRunner(cfg, dbt_invoke=_invoker_with_nodes(), runtime=_Local())
+        report = runner.run(only=["build"])
+        assert [o.command for o in report.outcomes] == ["build"]
+        assert report.metric_rows_written == 1
+
+    def test_run_operation_skipped_when_macro_absent(self, tmp_path):
+        cfg = _make_config(
+            tmp_path,
+            pipeline=[
+                {"command": "deps"},
+                {"command": "run-operation", "macro": "cleanup_dbt_tmp_relations", "if_macro_exists": True},
+            ],
+            metrics={"enabled": False},
+        )
+        runner = DbtRunner(cfg, dbt_invoke=_invoker_with_nodes(), runtime=_Local())
+        report = runner.run()
+        op = next(o for o in report.outcomes if o.command == "run-operation")
+        assert op.skipped is True
+
+
+class TestRunFailure:
+    def test_failing_step_raises_dbt_step_error(self, tmp_path):
+        cfg = _make_config(tmp_path)
+
+        def fake_invoke(args):
+            if args[0] == "build":
+                return fake_invoke_result(success=False, exception=RuntimeError("explode"))
+            if args[0] == "seed":
+                return fake_invoke_result(success=True, node_results=[fake_node_result()])
+            return fake_invoke_result(success=True)
+
+        runner = DbtRunner(cfg, dbt_invoke=fake_invoke, runtime=_Local())
+        with pytest.raises(DbtStepError, match="build failed"):
+            runner.run()
+
+    def test_partial_metrics_survive_failure(self, tmp_path):
+        from deltalake import DeltaTable
+
+        cfg = _make_config(tmp_path)
+
+        def fake_invoke(args):
+            if args[0] == "build":
+                return fake_invoke_result(success=False, exception=RuntimeError("explode"))
+            if args[0] == "seed":
+                return fake_invoke_result(success=True, node_results=[fake_node_result()])
+            return fake_invoke_result(success=True)
+
+        runner = DbtRunner(cfg, dbt_invoke=fake_invoke, runtime=_Local())
+        with pytest.raises(DbtStepError):
+            runner.run()
+        # seed's metric row was still flushed in the finally phase.
+        dt = DeltaTable(str(tmp_path / "delta" / "dbt_node_executions"))
+        assert dt.to_pyarrow_table().num_rows == 1
+
+
+class TestConstructors:
+    def test_rejects_non_config(self):
+        with pytest.raises(Exception):
+            DbtRunner({"not": "a config"})  # type: ignore[arg-type]
+
+    def test_from_mapping_roundtrip(self, tmp_path):
+        cfg_payload = runner_payload(metrics={"enabled": False}, pipeline=[{"command": "deps"}])
+        runner = DbtRunner.from_mapping(cfg_payload, dbt_invoke=lambda args: fake_invoke_result(success=True), runtime=_Local())
+        assert runner.validate().project_name == "dbt-example"
+        report = runner.run()
+        assert report.success is True

--- a/projects/fabric/python/dbt-runner-lib/tests/test_runtime.py
+++ b/projects/fabric/python/dbt-runner-lib/tests/test_runtime.py
@@ -1,0 +1,69 @@
+"""Tests for `dbt_runner.runtime`."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from _helpers import runner_payload
+from dbt_runner.config import RunnerConfig
+from dbt_runner.errors import FabricRuntimeUnavailableError
+from dbt_runner.runtime import FabricRuntime, LocalRuntime, make_runtime
+
+
+class TestMakeRuntime:
+    def test_local(self):
+        cfg = RunnerConfig.from_mapping(runner_payload(runtime="local"))
+        assert isinstance(make_runtime(cfg), LocalRuntime)
+
+    def test_fabric(self):
+        cfg = RunnerConfig.from_mapping(runner_payload(runtime="fabric"))
+        assert isinstance(make_runtime(cfg), FabricRuntime)
+
+
+class TestLocalRuntime:
+    def test_storage_options_none(self):
+        assert LocalRuntime().storage_options() is None
+
+    def test_onelake_context_empty(self):
+        assert LocalRuntime().onelake_context() == (None, None)
+
+    def test_get_token_raises(self):
+        with pytest.raises(FabricRuntimeUnavailableError, match="local"):
+            LocalRuntime().get_token("pbi")
+
+
+class TestFabricRuntime:
+    def test_get_token_without_notebookutils(self):
+        sys.modules.pop("notebookutils", None)
+        with pytest.raises(FabricRuntimeUnavailableError, match="notebookutils"):
+            FabricRuntime().get_token("storage")
+
+    def test_get_token_and_storage_options(self, monkeypatch):
+        nbu = types.ModuleType("notebookutils")
+        nbu.credentials = types.SimpleNamespace(getToken=lambda audience: f"token-for-{audience}")
+        monkeypatch.setitem(sys.modules, "notebookutils", nbu)
+        rt = FabricRuntime()
+        assert rt.get_token("storage") == "token-for-storage"
+        assert rt.storage_options() == {"bearer_token": "token-for-storage", "use_fabric_endpoint": "true"}
+
+    def test_get_token_rejects_empty(self, monkeypatch):
+        nbu = types.ModuleType("notebookutils")
+        nbu.credentials = types.SimpleNamespace(getToken=lambda audience: "")
+        monkeypatch.setitem(sys.modules, "notebookutils", nbu)
+        with pytest.raises(FabricRuntimeUnavailableError, match="returned"):
+            FabricRuntime().get_token("storage")
+
+    def test_onelake_context(self, monkeypatch):
+        nbu = types.ModuleType("notebookutils")
+        nbu.runtime = types.SimpleNamespace(context={"defaultLakehouseWorkspaceId": "ws-1", "defaultLakehouseId": "lh-1"})
+        monkeypatch.setitem(sys.modules, "notebookutils", nbu)
+        assert FabricRuntime().onelake_context() == ("ws-1", "lh-1")
+
+    def test_onelake_context_falls_back_to_current_workspace(self, monkeypatch):
+        nbu = types.ModuleType("notebookutils")
+        nbu.runtime = types.SimpleNamespace(context={"currentWorkspaceId": "ws-2", "defaultLakehouseId": "lh-2"})
+        monkeypatch.setitem(sys.modules, "notebookutils", nbu)
+        assert FabricRuntime().onelake_context() == ("ws-2", "lh-2")

--- a/projects/fabric/python/dbt-runner-lib/tests/test_session.py
+++ b/projects/fabric/python/dbt-runner-lib/tests/test_session.py
@@ -1,0 +1,106 @@
+"""Tests for `dbt_runner.session`."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import yaml
+
+from _helpers import runner_payload
+from dbt_runner.config import RunnerConfig
+from dbt_runner.session import SessionCloser, build_livy_delete_url, resolve_env_var
+
+
+class _FakeRuntime:
+    def get_token(self, audience):
+        return f"tok-{audience}"
+
+    def storage_options(self):
+        return None
+
+    def onelake_context(self):
+        return None, None
+
+
+class TestHelpers:
+    def test_build_url(self):
+        url = build_livy_delete_url("https://api.fabric.microsoft.com/v1", "ws", "lh", "sess-9")
+        assert url == "https://api.fabric.microsoft.com/v1/workspaces/ws/lakehouses/lh/livyApi/versions/2023-12-01/sessions/sess-9"
+
+    def test_resolve_env_var_prefers_env(self):
+        assert resolve_env_var("{{ env_var('K', 'default') }}", "K", {"K": "from-env"}) == "from-env"
+
+    def test_resolve_env_var_extracts_default(self):
+        assert resolve_env_var("{{ env_var('K', 'the-default') }}", "K", {}) == "the-default"
+
+    def test_resolve_env_var_passthrough(self):
+        assert resolve_env_var("literal-value", "K", {}) == "literal-value"
+
+
+def _profiles(tmp_path, target="fabric-fabric"):
+    session_file = tmp_path / "livy-session-id.txt"
+    session_file.write_text("session-123\n")
+    profiles = {
+        "example": {
+            "outputs": {
+                target: {
+                    "session_id_file": str(session_file),
+                    "workspaceid": "{{ env_var('FABRIC_WORKSPACE_ID', 'ws-default') }}",
+                    "lakehouseid": "{{ env_var('FABRIC_LAKEHOUSE_ID', 'lh-default') }}",
+                }
+            }
+        }
+    }
+    (tmp_path / "profiles.yml").write_text(yaml.safe_dump(profiles))
+
+
+class TestSessionCloser:
+    def test_close_disabled_is_noop(self, tmp_path):
+        cfg = RunnerConfig.from_mapping(runner_payload(profiles_dir=str(tmp_path)))
+        calls = []
+        SessionCloser(cfg, _FakeRuntime(), http_delete=lambda url, headers: calls.append(url)).close()
+        assert calls == []
+
+    def test_close_issues_delete(self, tmp_path):
+        _profiles(tmp_path)
+        cfg = RunnerConfig.from_mapping(
+            runner_payload(
+                profiles_dir=str(tmp_path),
+                target="fabric-fabric",
+                runtime="fabric",
+                session={"close": True, "target": "fabric-fabric"},
+            )
+        )
+        captured = {}
+
+        def fake_delete(url, headers):
+            captured["url"] = url
+            captured["headers"] = headers
+            return SimpleNamespace(status_code=200, reason="OK")
+
+        SessionCloser(cfg, _FakeRuntime(), env={}, http_delete=fake_delete).close()
+        assert captured["url"].endswith("/sessions/session-123")
+        assert "ws-default" in captured["url"]
+        assert "lh-default" in captured["url"]
+        assert captured["headers"]["Authorization"] == "Bearer tok-pbi"
+
+    def test_close_env_overrides_defaults(self, tmp_path):
+        _profiles(tmp_path)
+        cfg = RunnerConfig.from_mapping(
+            runner_payload(
+                profiles_dir=str(tmp_path),
+                target="fabric-fabric",
+                runtime="fabric",
+                session={"close": True, "target": "fabric-fabric"},
+            )
+        )
+        captured = {}
+        env = {"FABRIC_WORKSPACE_ID": "ws-real", "FABRIC_LAKEHOUSE_ID": "lh-real"}
+        SessionCloser(cfg, _FakeRuntime(), env=env, http_delete=lambda url, headers: captured.setdefault("url", url) or SimpleNamespace(status_code=200, reason="OK")).close()
+        assert "ws-real" in captured["url"]
+        assert "lh-real" in captured["url"]
+
+    def test_close_never_raises_on_missing_profiles(self, tmp_path):
+        cfg = RunnerConfig.from_mapping(runner_payload(profiles_dir=str(tmp_path), runtime="fabric", session={"close": True, "target": "fabric-fabric"}))
+        # No profiles.yml on disk — must warn, not raise.
+        SessionCloser(cfg, _FakeRuntime(), http_delete=lambda url, headers: None).close()

--- a/projects/fabric/template/sandbox/dbt_scheduler.Notebook/notebook-content.py
+++ b/projects/fabric/template/sandbox/dbt_scheduler.Notebook/notebook-content.py
@@ -22,7 +22,7 @@
 # MAGIC %%bash
 # MAGIC rm -rf /tmp/dbt-fabric-bundle
 # MAGIC tar -xzf /lakehouse/default/Files/onelake/pkgs/dbt-fabric-bundle.tar.gz -C /tmp
-# MAGIC pip install -q --no-index --find-links=/tmp/dbt-fabric-bundle/wheels dbt-core dbt-fabricspark deltalake pyarrow
+# MAGIC pip install -q --no-index --find-links=/tmp/dbt-fabric-bundle/wheels dbt-core dbt-fabricspark deltalake pyarrow dbt-runner-lib
 
 # METADATA ********************
 
@@ -45,361 +45,62 @@ full_refresh = "0"
 
 # CELL ********************
 
-import yaml
-import re
-import notebookutils
-import requests
+import base64
 import os
-import json
-import shutil
-from datetime import datetime, timezone
-import pyarrow as pa
-from deltalake import write_deltalake
-from dbt.cli.main import dbtRunner
-from dbt.version import __version__ as DBT_VERSION
-from dbt_common.events.event_manager_client import get_event_manager
-from dbt_common.invocation import get_invocation_id
 
-TARGET = "fabric-fabric"
+from dbt_runner import DbtRunner
 
-os.environ["GIT_ROOT"] = "/tmp/dbt-fabric-bundle"
-os.environ["DBT_LOG_PATH"] = f"/lakehouse/default/Files/onelake/logs/dbt/{dbt_project_name}"
-os.makedirs(os.environ["DBT_LOG_PATH"], exist_ok=True)
+if not dbt_project_name:
+    raise ValueError("dbt_project_name is empty. Set it locally in the PARAMETERS CELL above, or pass it via the Fabric pipeline parameter 'dbt_project_name' when invoking this notebook.")
 
-metrics_buffer = []
-INVOCATION_STARTED_AT = datetime.now(timezone.utc).replace(tzinfo=None)
-DBT_METRICS_DELTA_PATH = os.environ.get(
-    "DBT_METRICS_DELTA_PATH",
-    "/lakehouse/default/Files/onelake/raw/dbt/dbt_node_executions",
-)
-DBT_METRICS_RAW_PATH = os.environ.get(
-    "DBT_METRICS_RAW_PATH",
-    f"/lakehouse/default/Files/onelake/metrics/dbt/{dbt_project_name}",
-)
+GIT_ROOT = "/tmp/dbt-fabric-bundle"
+PROJECT_DIR = f"{GIT_ROOT}/projects/{dbt_project_name}"
+FULL_REFRESH = "true" if full_refresh == "1" else "false"
+METRICS_DELTA_PATH = os.environ.get("DBT_METRICS_DELTA_PATH", "/lakehouse/default/Files/onelake/raw/dbt/dbt_node_executions")
+METRICS_RAW_PATH = os.environ.get("DBT_METRICS_RAW_PATH", f"/lakehouse/default/Files/onelake/metrics/dbt/{dbt_project_name}")
 
-dbt_log_file = os.path.join(os.environ["DBT_LOG_PATH"], "dbt.log")
-if os.path.exists(dbt_log_file):
-    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    archived = os.path.join(os.environ["DBT_LOG_PATH"], f"dbt-archived-at-{ts}.log")
-    os.rename(dbt_log_file, archived)
-    print(f"Archived previous dbt.log to {archived}")
+RUNNER_YAML = f"""
+runner:
+  project_name: {dbt_project_name}
+  project_dir: {PROJECT_DIR}
+  profiles_dir: {PROJECT_DIR}
+  target: fabric-fabric
+  git_root: {GIT_ROOT}
+  runtime: fabric
+  vars: {{}}
+  pipeline:
+    - command: deps
+    - command: debug
+    - command: seed
+      full_refresh: {FULL_REFRESH}
+      collect_metrics: true
+      copy_run_results: true
+    - command: build
+      exclude: [resource_type:seed]
+      full_refresh: {FULL_REFRESH}
+      collect_metrics: true
+      copy_run_results: true
+    - command: run-operation
+      macro: cleanup_dbt_tmp_relations
+      if_macro_exists: true
+    - command: docs-generate
+  logging:
+    log_path: /lakehouse/default/Files/onelake/logs/dbt/{dbt_project_name}
+    archive_previous: true
+  metrics:
+    enabled: true
+    delta_path: {METRICS_DELTA_PATH}
+    raw_path: {METRICS_RAW_PATH}
+    partition_by: [project, event_year_month]
+    archive_previous_raw: true
+  session:
+    close: true
+    target: fabric-fabric
+"""
 
-for _command in ("seed", "build"):
-    try:
-        _current = os.path.join(DBT_METRICS_RAW_PATH, f"run_results-{_command}.json")
-        if os.path.exists(_current):
-            ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-            _archived = os.path.join(DBT_METRICS_RAW_PATH, f"run_results-{_command}-archived-at-{ts}.json")
-            os.rename(_current, _archived)
-            print(f"Archived previous run_results-{_command}.json to {_archived}")
-    except Exception as e:
-        print(f"Warning: failed to archive previous run_results-{_command}.json: {e}")
-
-
-def resolve_env_var(yaml_value, env_key):
-    """Return os.environ[env_key] if set, otherwise extract the default from a
-    dbt ``{{ env_var('KEY', 'default') }}`` template string."""
-    env_val = os.environ.get(env_key)
-    if env_val:
-        return env_val
-    m = re.search(r"\{\{\s*env_var\s*\(\s*'[^']*'\s*,\s*'([^']*)'\s*\)\s*\}\}", yaml_value)
-    if m:
-        return m.group(1)
-    return yaml_value
-
-
-def close_livy_session(project):
-    """Read session ID from project profile and close it."""
-    try:
-        profiles = yaml.safe_load(open(f"/tmp/dbt-fabric-bundle/projects/{project}/profiles.yml"))
-        profile_name = next(iter(profiles))
-        cfg = profiles[profile_name]["outputs"][TARGET]
-        session_id = open(cfg["session_id_file"]).read().strip()
-
-        workspace_id = resolve_env_var(cfg["workspaceid"], "FABRIC_WORKSPACE_ID")
-        lakehouse_id = resolve_env_var(cfg["lakehouseid"], "FABRIC_LAKEHOUSE_ID")
-
-        url = f"https://api.fabric.microsoft.com/v1/workspaces/{workspace_id}/lakehouses/{lakehouse_id}/livyApi/versions/2023-12-01/sessions/{session_id}"
-        print(f"Deleting session {session_id}: {url}")
-        r = requests.delete(url, headers={"Authorization": f"Bearer {notebookutils.credentials.getToken('pbi')}"})
-        print(f"Delete session {session_id}: {r.status_code} {r.reason}")
-    except Exception as e:
-        print(f"Warning: failed to close Livy session for {project}: {e}")
-
-
-def flush_dbt_logs():
-    """Flush dbt file logger and fsync to persistent storage (OneLake/FUSE).
-
-    cleanup_event_logger() clears loggers without flushing, so on a FUSE
-    filesystem the RotatingFileHandler's buffered writes may never reach
-    the backing store unless we explicitly flush + fsync.
-    """
-    try:
-        get_event_manager().flush()
-    except Exception:
-        pass
-    try:
-        with open(dbt_log_file, "a") as f:
-            os.fsync(f.fileno())
-    except OSError:
-        pass
-
-
-PA_SCHEMA = pa.schema(
-    [
-        ("project", pa.string()),
-        ("command", pa.string()),
-        ("invocation_id", pa.string()),
-        ("dbt_version", pa.string()),
-        ("generated_at", pa.timestamp("us", tz="UTC")),
-        ("unique_id", pa.string()),
-        ("resource_type", pa.string()),
-        ("package_name", pa.string()),
-        ("name", pa.string()),
-        ("alias", pa.string()),
-        ("database", pa.string()),
-        ("schema_name", pa.string()),
-        ("relation_name", pa.string()),
-        ("original_file_path", pa.string()),
-        ("materialized", pa.string()),
-        ("execution_time", pa.float64()),
-        ("compile_started_at", pa.timestamp("us", tz="UTC")),
-        ("compile_completed_at", pa.timestamp("us", tz="UTC")),
-        ("compile_time", pa.float64()),
-        ("execute_started_at", pa.timestamp("us", tz="UTC")),
-        ("execute_completed_at", pa.timestamp("us", tz="UTC")),
-        ("execute_time", pa.float64()),
-        ("thread_id", pa.string()),
-        ("status", pa.string()),
-        ("rows_affected", pa.int64()),
-        ("failures", pa.int64()),
-        ("message", pa.string()),
-        ("tags", pa.list_(pa.string())),
-        ("depends_on_nodes", pa.list_(pa.string())),
-        ("adapter_response_json", pa.string()),
-        ("config_json", pa.string()),
-        ("test_metadata_json", pa.string()),
-        ("raw_json", pa.string()),
-        ("event_year_month", pa.string()),
-    ]
-)
-
-
-def _safe_json(obj):
-    """Serialize anything to a JSON string, never raising."""
-    if obj is None:
-        return None
-    try:
-        return json.dumps(obj, default=str)
-    except Exception:
-        try:
-            return json.dumps(str(obj))
-        except Exception:
-            return None
-
-
-def _seconds_between(start, end):
-    if start is not None and end is not None:
-        return (end - start).total_seconds()
-    return None
-
-
-def _normalize_node_result(project, command, r, generated_at, invocation_id):
-    """Flatten a single dbtRunner node result into a PA_SCHEMA-shaped dict."""
-    node = getattr(r, "node", None)
-    cfg = getattr(node, "config", None)
-
-    compile_started = compile_completed = execute_started = execute_completed = None
-    for ti in getattr(r, "timing", None) or []:
-        if ti.name == "compile":
-            compile_started, compile_completed = ti.started_at, ti.completed_at
-        elif ti.name == "execute":
-            execute_started, execute_completed = ti.started_at, ti.completed_at
-
-    adapter = getattr(r, "adapter_response", None) or {}
-    rows_affected = adapter.get("rows_affected") if isinstance(adapter, dict) else None
-    failures = getattr(r, "failures", None)
-
-    depends_on = getattr(node, "depends_on", None)
-    depends_on_nodes = list(getattr(depends_on, "nodes", None) or []) if depends_on is not None else []
-    test_metadata = getattr(node, "test_metadata", None)
-
-    part_dt = execute_completed or generated_at or INVOCATION_STARTED_AT
-
-    return {
-        "project": project,
-        "command": command,
-        "invocation_id": invocation_id,
-        "dbt_version": DBT_VERSION,
-        "generated_at": generated_at,
-        "unique_id": getattr(node, "unique_id", None),
-        "resource_type": str(getattr(node, "resource_type", "") or "") or None,
-        "package_name": getattr(node, "package_name", None),
-        "name": getattr(node, "name", None),
-        "alias": getattr(node, "alias", None),
-        "database": getattr(node, "database", None),
-        "schema_name": getattr(node, "schema", None),
-        "relation_name": getattr(node, "relation_name", None),
-        "original_file_path": getattr(node, "original_file_path", None),
-        "materialized": getattr(cfg, "materialized", None),
-        "execution_time": getattr(r, "execution_time", None),
-        "compile_started_at": compile_started,
-        "compile_completed_at": compile_completed,
-        "compile_time": _seconds_between(compile_started, compile_completed),
-        "execute_started_at": execute_started,
-        "execute_completed_at": execute_completed,
-        "execute_time": _seconds_between(execute_started, execute_completed),
-        "thread_id": getattr(r, "thread_id", None),
-        "status": str(getattr(r, "status", "") or "") or None,
-        "rows_affected": int(rows_affected) if isinstance(rows_affected, (int, float)) else None,
-        "failures": int(failures) if failures is not None else None,
-        "message": getattr(r, "message", None),
-        "tags": list(getattr(node, "tags", None) or []),
-        "depends_on_nodes": depends_on_nodes,
-        "adapter_response_json": _safe_json(adapter),
-        "config_json": _safe_json(cfg.to_dict() if hasattr(cfg, "to_dict") else cfg),
-        "test_metadata_json": _safe_json(test_metadata.to_dict() if hasattr(test_metadata, "to_dict") else test_metadata),
-        "raw_json": _safe_json(r.to_dict() if hasattr(r, "to_dict") else None),
-        "event_year_month": part_dt.strftime("%Y%m") if part_dt is not None else None,
-    }
-
-
-def collect_node_metrics(project, command, result):
-    """Append normalized node rows from a dbtRunner result to metrics_buffer.
-
-    Never raises: deps/debug have no node results (no-op); errors are printed.
-    """
-    try:
-        run_result = getattr(result, "result", None)
-        results = getattr(run_result, "results", None)
-        if not results:
-            return
-        generated_at = getattr(run_result, "generated_at", None)
-        try:
-            invocation_id = get_invocation_id()
-        except Exception:
-            invocation_id = None
-        for r in results:
-            try:
-                metrics_buffer.append(_normalize_node_result(project, command, r, generated_at, invocation_id))
-            except Exception as e:
-                print(f"[{project}] metrics normalize ({command}) failed for one node: {e}")
-    except Exception as e:
-        print(f"[{project}] metrics collect ({command}) failed: {e}")
-
-
-def copy_run_results(project, command, project_dir):
-    """Copy dbt's run_results.json verbatim before the next command overwrites it.
-
-    Never raises: errors are printed only.
-    """
-    try:
-        src = os.path.join(project_dir, "target", "run_results.json")
-        if not os.path.exists(src):
-            return
-        os.makedirs(DBT_METRICS_RAW_PATH, exist_ok=True)
-        dst = os.path.join(DBT_METRICS_RAW_PATH, f"run_results-{command}.json")
-        shutil.copyfile(src, dst)
-        try:
-            with open(dst, "a") as f:
-                os.fsync(f.fileno())
-        except OSError:
-            pass
-        print(f"[{project}] archived run_results.json -> {dst}")
-    except Exception as e:
-        print(f"[{project}] raw run_results copy ({command}) failed: {e}")
-
-
-def _onelake_storage_options():
-    """delta-rs object-store options for the OneLake abfss endpoint."""
-    return {
-        "bearer_token": notebookutils.credentials.getToken("storage"),
-        "use_fabric_endpoint": "true",
-    }
-
-
-def _resolve_delta_target():
-    """Map the metrics Delta path to a writable (uri, storage_options) target.
-
-    The OneLake FUSE mount (/lakehouse/...) cannot be used by delta-rs because
-    its commit step needs an atomic rename the FUSE driver rejects
-    ("Operation not permitted"). So a OneLake FUSE path is rewritten to the
-    abfss object-store endpoint (which commits via ADLS, not local rename).
-    A path already in abfss form is used as-is; any other (genuinely local)
-    path is written directly with no storage options.
-    """
-    path = DBT_METRICS_DELTA_PATH
-    if path.startswith("abfss://"):
-        return path, _onelake_storage_options()
-    prefix = "/lakehouse/default/Files/"
-    if path.startswith(prefix):
-        ctx = notebookutils.runtime.context
-        workspace_id = ctx.get("defaultLakehouseWorkspaceId") or ctx.get("currentWorkspaceId")
-        lakehouse_id = ctx.get("defaultLakehouseId")
-        rel = path[len(prefix) :]
-        uri = f"abfss://{workspace_id}@onelake.dfs.fabric.microsoft.com/{lakehouse_id}/Files/{rel}"
-        return uri, _onelake_storage_options()
-    return path, None
-
-
-def flush_metrics_to_delta(project):
-    """Single append of the buffered node metrics to the Delta table.
-
-    Called once in finally so partial results survive a mid-run failure.
-    Never raises: errors are printed only.
-    """
-    try:
-        if not metrics_buffer:
-            print(f"[{project}] no node metrics to write")
-            return
-        uri, storage_options = _resolve_delta_target()
-        table = pa.Table.from_pylist(metrics_buffer, schema=PA_SCHEMA)
-        kwargs = {"mode": "append", "partition_by": ["project", "event_year_month"]}
-        if storage_options is not None:
-            kwargs["storage_options"] = storage_options
-        else:
-            os.makedirs(os.path.dirname(uri), exist_ok=True)
-        write_deltalake(uri, table, **kwargs)
-        print(f"[{project}] wrote {len(metrics_buffer)} node metric rows to {uri}")
-    except Exception as e:
-        print(f"[{project}] metrics delta flush failed: {e}")
-
-
-def run_dbt_project(project):
-    project_dir = f"/tmp/dbt-fabric-bundle/projects/{project}"
-
-    base_args = ["--project-dir", project_dir, "--profiles-dir", project_dir, "--target", TARGET]
-    refresh_args = ["--full-refresh"] if full_refresh == "1" else []
-
-    runner = dbtRunner()
-    for cmd in [
-        ["deps"] + base_args,
-        ["debug"] + base_args,
-        ["seed", "--full-refresh"] + base_args,
-        ["build", "--exclude", "resource_type:seed"] + base_args + refresh_args,
-    ]:
-        result = runner.invoke(cmd)
-        flush_dbt_logs()
-        collect_node_metrics(project, cmd[0], result)
-        if cmd[0] in ("seed", "build"):
-            copy_run_results(project, cmd[0], project_dir)
-        print(f"[{project}] {cmd[0]}: {'success' if result.success else 'FAILED'}")
-        if not result.success:
-            detail = ""
-            if result.exception:
-                detail = f"\n  Exception: {result.exception}"
-            if hasattr(result, "result") and result.result:
-                detail += f"\n  Result: {result.result}"
-            raise RuntimeError(f"[{project}] {cmd[0]} failed{detail}")
-    return project
-
-
+config_b64 = base64.b64encode(RUNNER_YAML.encode()).decode()
 print(f"Running dbt project: {dbt_project_name}")
-try:
-    run_dbt_project(dbt_project_name)
-finally:
-    flush_metrics_to_delta(dbt_project_name)
-    close_livy_session(dbt_project_name)
+DbtRunner.from_base64(config_b64).run()
 
 # METADATA ********************
 

--- a/projects/spark-dbt/.cleanpaths
+++ b/projects/spark-dbt/.cleanpaths
@@ -3,6 +3,7 @@ dist
 __pycache__
 .venv
 .hatch
+.temp
 .pytest_cache
 .mypy_cache
 .ruff_cache

--- a/projects/spark-dbt/.github/copilot-instructions.md
+++ b/projects/spark-dbt/.github/copilot-instructions.md
@@ -15,7 +15,7 @@ projects/spark-dbt/
 ├── pyproject.toml                # hatch venv; pinned dbt-fabricspark==1.12.5 (uv installer)
 ├── project.json                  # nx root: clean, install, init, run, package, compile, lint
 ├── .scripts/
-│   ├── run-dbt-local.sh          # one-project loop: debug → deps → seed → build → cleanup → docs
+│   ├── run-dbt-local.sh          # thin wrapper: builds inline YAML → dbt-runner-lib (deps → debug → seed → build → cleanup → docs + metrics)
 │   ├── lint-dbt.sh               # per-project lint: black (Python) + sqlfluff fix/lint (SQL)
 │   ├── package-fabric.sh         # packages all dbt projects into a Fabric deploy bundle
 │   ├── compile-erd.sh            # ERD compile (dbterd)
@@ -166,7 +166,7 @@ npx nx run spark-dbt:compile
 npx nx run spark-dbt:package
 ```
 
-`run-dbt-local.sh` invokes: `dbt debug → dbt deps → dbt seed → dbt build --exclude resource_type:seed → cleanup_dbt_tmp_relations (if macro exists) → dbt docs generate`.
+`run-dbt-local.sh` is a thin wrapper: it builds an inline-YAML `runner:` config (local-local target, metrics localized under `.temp/dbt-runner/<project>`) and hands it to the shared **`dbt-runner-lib`** (`projects/fabric/python/dbt-runner-lib`), which executes the pipeline `dbt deps → debug → seed → build --exclude resource_type:seed → cleanup_dbt_tmp_relations (if macro exists) → docs generate`, collects node-execution metrics, and writes the **same** Delta table (`dbt_node_executions`) the Fabric `dbt_scheduler` notebook produces — only the paths differ. The library is an editable dependency of the spark-dbt hatch venv (installed by `spark-dbt:install`) and is bundled into `dbt-fabric-bundle.tar.gz` by `package-fabric.sh`. See [`projects/fabric/python/dbt-runner-lib/README.md`](../../fabric/python/dbt-runner-lib/README.md) for the full YAML contract.
 
 ---
 

--- a/projects/spark-dbt/.scripts/package-fabric.sh
+++ b/projects/spark-dbt/.scripts/package-fabric.sh
@@ -22,7 +22,23 @@ source .venv/bin/activate
 OUT="${1:-dist}"
 rm -rf "$OUT" && mkdir -p "$OUT/$BUNDLE_NAME"/{wheels,projects}
 
+GIT_ROOT=$(git rev-parse --show-toplevel)
+RUNNER_LIB_DIST="${GIT_ROOT}/projects/fabric/python/dbt-runner-lib/dist"
+mapfile -t RUNNER_WHEELS < <(ls "${RUNNER_LIB_DIST}"/dbt_runner_lib-*.whl 2>/dev/null)
+if [[ ${#RUNNER_WHEELS[@]} -eq 0 ]]; then
+  echo "ERROR: dbt_runner_lib wheel not found. Run 'npx nx run dbt-runner-lib:build' first." >&2
+  exit 1
+fi
+if [[ ${#RUNNER_WHEELS[@]} -gt 1 ]]; then
+  echo "ERROR: multiple dbt_runner_lib wheels in ${RUNNER_LIB_DIST}. Clean stale builds:" >&2
+  printf '  %s\n' "${RUNNER_WHEELS[@]}" >&2
+  exit 1
+fi
+RUNNER_WHEEL="${RUNNER_WHEELS[0]}"
+echo "Using dbt-runner-lib wheel: $(basename "${RUNNER_WHEEL}")"
+
 hatch dep show requirements 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g' | \
+  sed "s|^dbt[-_]runner[-_]lib\s*@\s*file://.*$|dbt-runner-lib @ file://${RUNNER_WHEEL}|" | \
   pip download -q --dest "$OUT/$BUNDLE_NAME/wheels" --python-version "$PYTHON_VERSION" \
   $(printf -- '--platform %s ' $PLATFORMS) --only-binary=:all: -r /dev/stdin
 

--- a/projects/spark-dbt/.scripts/run-dbt-local.sh
+++ b/projects/spark-dbt/.scripts/run-dbt-local.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 #
 #
-#       Script to run a dbt project end-to-end, including debug, deps, build,
-#       and docs generation.
+#       Run a dbt project end-to-end through the shared `dbt-runner-lib`.
+#
+#       This script is a thin wrapper: it builds the inline-YAML `runner:`
+#       config (local-local target, metrics localized under .temp/dbt-runner),
+#       base64-encodes it, and hands it to `python -m dbt_runner run`. The
+#       library performs deps/debug/seed/build/cleanup/docs, collects node
+#       metrics, and writes the SAME Delta table Fabric produces — only the
+#       paths differ.
 #
 #       Usage: run-dbt-local.sh <dbt-project> [target]
 #       Example: run-dbt-local.sh dbt-adventureworks local-local
@@ -11,6 +17,10 @@
 #         local-local   - Local dbt client + Local spark server (default)
 #         local-fabric  - Local dbt client + Fabric spark server
 #         fabric-fabric - Fabric dbt client + Fabric spark server
+#
+#       Env:
+#         FULL_REFRESH=1  - pass --full-refresh to seed + build
+#         DBT_DEBUG=true  - verbose dbt logging
 #
 # ---------------------------------------------------------------------------------------
 #
@@ -31,27 +41,71 @@ DBT_PROJECT="$1"
 DBT_TARGET="${2:-local-local}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "${SCRIPT_DIR}/.."
+SPARK_DBT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+GIT_ROOT="$(git -C "${SPARK_DBT_DIR}" rev-parse --show-toplevel)"
+
+cd "${SPARK_DBT_DIR}"
 source .venv/bin/activate
 
-cd "${DBT_PROJECT}"
-
-export DBT_PROFILES_DIR=$(pwd)
 export DBT_DEBUG="${DBT_DEBUG:-false}"
 FULL_REFRESH="${FULL_REFRESH:-0}"
-
-FULL_REFRESH_FLAG=""
 if [[ "${FULL_REFRESH}" == "1" ]]; then
-    FULL_REFRESH_FLAG="--full-refresh"
+    FR="true"
+else
+    FR="false"
+fi
+
+PROJECT_DIR="${SPARK_DBT_DIR}/${DBT_PROJECT}"
+OUT_DIR="${SPARK_DBT_DIR}/.temp/dbt-runner"
+PROJECT_OUT_DIR="${OUT_DIR}/${DBT_PROJECT}"
+
+if [[ ! -d "${PROJECT_DIR}" ]]; then
+    echo "Error: dbt project directory not found: ${PROJECT_DIR}" >&2
+    exit 1
 fi
 
 echo "Running dbt project '${DBT_PROJECT}' with target '${DBT_TARGET}' (full_refresh=${FULL_REFRESH})"
+echo "Metrics + logs localized under: ${PROJECT_OUT_DIR}"
 
-dbt debug --target "${DBT_TARGET}"
-dbt deps
-dbt seed --target "${DBT_TARGET}" ${FULL_REFRESH_FLAG}
-dbt build --exclude resource_type:seed --target "${DBT_TARGET}" ${FULL_REFRESH_FLAG}
-if grep -rql 'macro cleanup_dbt_tmp_relations' macros/ 2>/dev/null; then
-    dbt run-operation cleanup_dbt_tmp_relations --target "${DBT_TARGET}"
-fi
-dbt docs generate --target "${DBT_TARGET}"
+RUNNER_YAML=$(cat <<YAML
+runner:
+  project_name: ${DBT_PROJECT}
+  project_dir: ${PROJECT_DIR}
+  profiles_dir: ${PROJECT_DIR}
+  target: ${DBT_TARGET}
+  git_root: ${GIT_ROOT}
+  runtime: local
+  vars: {}
+  pipeline:
+    - command: deps
+    - command: debug
+    - command: seed
+      full_refresh: ${FR}
+      collect_metrics: true
+      copy_run_results: true
+    - command: build
+      exclude: [resource_type:seed]
+      full_refresh: ${FR}
+      collect_metrics: true
+      copy_run_results: true
+    - command: run-operation
+      macro: cleanup_dbt_tmp_relations
+      if_macro_exists: true
+    - command: docs-generate
+  logging:
+    log_path: ${PROJECT_OUT_DIR}/logs
+    archive_previous: true
+  metrics:
+    enabled: true
+    delta_path: ${OUT_DIR}/raw/dbt/dbt_node_executions
+    raw_path: ${PROJECT_OUT_DIR}/metrics/dbt/${DBT_PROJECT}
+    partition_by: [project, event_year_month]
+    archive_previous_raw: true
+  session:
+    close: false
+YAML
+)
+
+RUNNER_CONFIG_B64=$(printf '%s' "${RUNNER_YAML}" | base64 -w0)
+
+python -m dbt_runner run --config-base64 "${RUNNER_CONFIG_B64}"

--- a/projects/spark-dbt/dbt-adventureworks/project.json
+++ b/projects/spark-dbt/dbt-adventureworks/project.json
@@ -15,7 +15,9 @@
       "inputs": [
         "{projectRoot}/**/*",
         "{workspaceRoot}/projects/spark-dbt/.scripts/run-dbt-local.sh",
-        "{workspaceRoot}/projects/spark-dbt/pyproject.toml"
+        "{workspaceRoot}/projects/spark-dbt/pyproject.toml",
+        "{workspaceRoot}/projects/fabric/python/dbt-runner-lib/src/dbt_runner/**/*",
+        "{workspaceRoot}/projects/fabric/python/dbt-runner-lib/pyproject.toml"
       ],
       "options": {
         "cwd": "projects/spark-dbt",

--- a/projects/spark-dbt/dbt-dataops/models/marts/fct_delta_commit.sql
+++ b/projects/spark-dbt/dbt-dataops/models/marts/fct_delta_commit.sql
@@ -18,9 +18,9 @@ WITH src AS (
         ) AS _row_num
     FROM {{ ref('stg_delta_commit_history') }}
     {% if is_incremental() %}
-    where
-        snapshot_date >= (select date_format(max(commit_timestamp), 'yyyyMMdd') from {{ this }})
-        and commit_timestamp > (select max(commit_timestamp) from {{ this }})
+        WHERE
+            snapshot_date >= (SELECT date_format(max(commit_timestamp), 'yyyyMMdd') FROM {{ this }})
+            AND commit_timestamp > (SELECT max(commit_timestamp) FROM {{ this }})
     {% endif %}
 ),
 

--- a/projects/spark-dbt/dbt-dataops/models/marts/fct_delta_health.sql
+++ b/projects/spark-dbt/dbt-dataops/models/marts/fct_delta_health.sql
@@ -18,9 +18,9 @@ WITH src AS (
         ) AS _row_num
     FROM {{ ref('stg_delta_kpi_results') }}
     {% if is_incremental() %}
-    where
-        date_key >= (select max(date_key) from {{ this }})
-        and evaluation_timestamp > (select max(evaluation_timestamp) from {{ this }})
+        WHERE
+            date_key >= (SELECT max(date_key) FROM {{ this }})
+            AND evaluation_timestamp > (SELECT max(evaluation_timestamp) FROM {{ this }})
     {% endif %}
 ),
 

--- a/projects/spark-dbt/dbt-dataops/models/marts/fct_delta_lineage_dependency.sql
+++ b/projects/spark-dbt/dbt-dataops/models/marts/fct_delta_lineage_dependency.sql
@@ -18,9 +18,9 @@
 WITH src AS (
     SELECT * FROM {{ ref('stg_delta_lineage') }}
     {% if is_incremental() %}
-    where
-        event_year_date >= (select date_format(max(last_seen_timestamp), 'yyyyMMdd') from {{ this }})
-        and event_timestamp > (select max(last_seen_timestamp) from {{ this }})
+        WHERE
+            event_year_date >= (SELECT date_format(max(last_seen_timestamp), 'yyyyMMdd') FROM {{ this }})
+            AND event_timestamp > (SELECT max(last_seen_timestamp) FROM {{ this }})
     {% endif %}
 ),
 

--- a/projects/spark-dbt/dbt-dataops/models/marts/fct_delta_storage.sql
+++ b/projects/spark-dbt/dbt-dataops/models/marts/fct_delta_storage.sql
@@ -18,9 +18,9 @@ WITH raw_snapshots AS (
         ) AS _row_num
     FROM {{ source('dataops_inventory', 'table_snapshots') }}
     {% if is_incremental() %}
-    where
-        snapshot_date >= (select max(date_key) from {{ this }})
-        and ingested_at > (select max(ingested_at) from {{ this }})
+        WHERE
+            snapshot_date >= (SELECT max(date_key) FROM {{ this }})
+            AND ingested_at > (SELECT max(ingested_at) FROM {{ this }})
     {% endif %}
 ),
 

--- a/projects/spark-dbt/dbt-dataops/project.json
+++ b/projects/spark-dbt/dbt-dataops/project.json
@@ -15,7 +15,9 @@
       "inputs": [
         "{projectRoot}/**/*",
         "{workspaceRoot}/projects/spark-dbt/.scripts/run-dbt-local.sh",
-        "{workspaceRoot}/projects/spark-dbt/pyproject.toml"
+        "{workspaceRoot}/projects/spark-dbt/pyproject.toml",
+        "{workspaceRoot}/projects/fabric/python/dbt-runner-lib/src/dbt_runner/**/*",
+        "{workspaceRoot}/projects/fabric/python/dbt-runner-lib/pyproject.toml"
       ],
       "options": {
         "cwd": "projects/spark-dbt",

--- a/projects/spark-dbt/dbt-jaffle-shop/project.json
+++ b/projects/spark-dbt/dbt-jaffle-shop/project.json
@@ -15,7 +15,9 @@
       "inputs": [
         "{projectRoot}/**/*",
         "{workspaceRoot}/projects/spark-dbt/.scripts/run-dbt-local.sh",
-        "{workspaceRoot}/projects/spark-dbt/pyproject.toml"
+        "{workspaceRoot}/projects/spark-dbt/pyproject.toml",
+        "{workspaceRoot}/projects/fabric/python/dbt-runner-lib/src/dbt_runner/**/*",
+        "{workspaceRoot}/projects/fabric/python/dbt-runner-lib/pyproject.toml"
       ],
       "options": {
         "cwd": "projects/spark-dbt",

--- a/projects/spark-dbt/dbt-reddit/project.json
+++ b/projects/spark-dbt/dbt-reddit/project.json
@@ -15,7 +15,9 @@
       "inputs": [
         "{projectRoot}/**/*",
         "{workspaceRoot}/projects/spark-dbt/.scripts/run-dbt-local.sh",
-        "{workspaceRoot}/projects/spark-dbt/pyproject.toml"
+        "{workspaceRoot}/projects/spark-dbt/pyproject.toml",
+        "{workspaceRoot}/projects/fabric/python/dbt-runner-lib/src/dbt_runner/**/*",
+        "{workspaceRoot}/projects/fabric/python/dbt-runner-lib/pyproject.toml"
       ],
       "options": {
         "cwd": "projects/spark-dbt",

--- a/projects/spark-dbt/project.json
+++ b/projects/spark-dbt/project.json
@@ -2,6 +2,7 @@
   "name": "spark-dbt",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
+  "implicitDependencies": ["dbt-runner-lib"],
   "targets": {
     "clean": {
       "executor": "nx:run-commands",
@@ -29,7 +30,10 @@
       "dependsOn": ["clean"],
       "options": {
         "cwd": "projects/spark-dbt",
-        "commands": ["hatch env create"],
+        "commands": [
+          "hatch env create",
+          "uv pip install --link-mode=copy --python .venv/bin/python -e ../fabric/python/dbt-runner-lib --no-deps"
+        ],
         "parallel": false
       }
     },
@@ -67,7 +71,13 @@
       }
     },
     "package": {
-      "dependsOn": ["install"],
+      "dependsOn": [
+        "install",
+        {
+          "target": "build",
+          "projects": ["dbt-runner-lib"]
+        }
+      ],
       "executor": "nx:run-commands",
       "options": {
         "cwd": "projects/spark-dbt",

--- a/projects/spark-dbt/pyproject.toml
+++ b/projects/spark-dbt/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "sqlfluff-templater-dbt",
   "deltalake",
   "pyarrow",
+  "dbt-runner-lib @ {root:uri}/../fabric/python/dbt-runner-lib",
 ]
 
 [tool.hatch.envs.default.env-vars]


### PR DESCRIPTION
# Why this change is needed

`dbt-runner` logic was duplicated across the local script and the Fabric scheduler notebook, so the two paths could drift. Closes #66.

# How

New standalone package `projects/fabric/python/dbt-runner-lib`: one config-driven runner that takes a single base64 inline-YAML payload — `DbtRunner.from_base64(b64).run()`. Both entry points (`run-dbt-local.sh` and the Fabric notebook) now build that YAML and call the shared lib, so they can't diverge. The wheel is bundled into `dbt-fabric-bundle.tar.gz` (`package-fabric.sh`) and editable-installed into the `spark-dbt` hatch venv.

# Test

`npx nx run dbt-runner-lib:test` → 111 passed. Affected lint clean.

# Checklist

- [x] Pull Request Title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Linting - ran `npx nx affected --base=origin/main -t lint --configuration=ci --verbose` locally
