### PR TITLE
feat(dataops): observability model + dashboard (Delta Lake, OpenLineage, dbt)

### DIFF
--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -44,9 +44,12 @@ The skill will ask for the PR URL and the failed CI run URL, then orchestrate th
 
 ## 📊 dbt → Power BI
 
-End-to-end workflow to ship a Power BI report from a Delta Lake: Kimball dbt model → matplotlib mockup → TMDL semantic model → PBIR visual JSON — skipping the Power BI UI almost entirely.
+End-to-end workflow to ship a Power BI report from a Delta Lake: Kimball dbt model → matplotlib mockup → TMDL semantic model → PBIR visual JSON — skipping the Power BI UI almost entirely. The SKILL also references [`skills-for-fabric`](https://github.com/microsoft/skills-for-fabric).
 
 ```bash
+/plugin marketplace add microsoft/skills-for-fabric
+/plugin install powerbi-authoring@fabric-collection
+
 /fleet @//workspaces/spark-sandbox/.github/skills/dbt-to-power-bi/skill.md
 ```
 

--- a/.github/skills/dbt-to-power-bi/skill.md
+++ b/.github/skills/dbt-to-power-bi/skill.md
@@ -39,13 +39,19 @@ A complete output from this skill produces:
 - **Semantic model**: `projects/fabric/workspace-automation/<workspace>/<name>.SemanticModel/definition/` (one `.tmdl` per dim/fact, `Report Measures.tmdl`, `relationships.tmdl`)
 - **PBIR report**: `projects/fabric/workspace-automation/<workspace>/Reports/<area>/<name>.Report/`
 
+You should also use the following SKILLs available to you that were installed via a plugin officially from Microsoft to author Power BI reports:
+
+- `semantic-model-authoring`: Develops and manages Power BI semantic models across Desktop, PBIP projects, and Fabric Service.
+- `powerbi-report-planning`: Build a guided requirements-to-implementation workflow for new Power BI reports and dashboards from semantic models, datasets, or PBIP projects.
+- `powerbi-report-design`: Generate Power BI report visual design guidance before PBIR files are written.
+- `powerbi-report-authoring`: Create and modify Power BI report files in PBIR/PBIP format using the `powerbi-report-author` and `powerbi-desktop` CLIs.
+- `powerbi-report-management`: Manage Power BI report workspace items in Microsoft Fabric via `az rest` CLI against the Fabric REST API.
+
 Skill templates you can copy from:
 
 - [`templates/matplotlib_report.py`](templates/matplotlib_report.py) — Power BI-themed matplotlib skeleton with `draw_card` / `panel` helpers
 - [`templates/report_measures.tmdl`](templates/report_measures.tmdl) — TMDL `Report Measures` table with hidden dummy column
 - [`templates/generate_pbir_visuals.py`](templates/generate_pbir_visuals.py) — PBIR JSON generator for 5 visual archetypes
-
-> ⚠️ This repo does **not** ship a committed PBIR Report you can template-clone from. Before Step 6, you need to either (a) generate one visual in the Fabric UI and commit it to seed the JSON schema, or (b) bring your own known-working PBIR folder and adapt [`templates/generate_pbir_visuals.py`](templates/generate_pbir_visuals.py) to it. See Step 6a for the workaround.
 
 ---
 
@@ -358,12 +364,8 @@ This step replaces "click-ops in the Power BI UI" with `git add`-able JSON.
 
 PBIR (Power BI Report) is a folder of JSON files. The schema is **template-friendly but undocumented**. Always copy from a known-working report rather than writing JSON from scratch.
 
-⚠️ **This repo does not ship a committed PBIR Report.** Before you can generate visuals, you need a seed template. Two paths:
+Fabric items live in `projects/fabric/template/sandbox/`, and there's already a committed `adventureworks.SemanticModel` and `adventureworks.Report` (PBIR).
 
-1. **Generate one in the Fabric UI** (easiest): open Fabric → New Report → save → export the `.Report` folder via Power BI Desktop Developer Mode or Fabric Git integration. Commit it under `projects/fabric/workspace-automation/<workspace>/Reports/<area>/<name>.Report/`.
-2. **Bring your own**: any production PBIR folder you have access to will work — copy it into the repo and adapt the generator script to match its `report.json`/`pages.json` schema version.
-
-The generator script (Step 6c) assumes the standard PBIR JSON shape: a `report.json` + `pages.json` at the root, then `pages/<page-id>/page.json` + `pages/<page-id>/visuals/<20-char-hex>/visual.json` per visual. Any seed that follows this shape will work.
 
 ### 6b — Visual archetypes
 

--- a/projects/fabric/template/sandbox/dataops.Report/.platform
+++ b/projects/fabric/template/sandbox/dataops.Report/.platform
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/gitIntegration/platformProperties/2.0.0/schema.json",
+  "metadata": {
+    "type": "Report",
+    "displayName": "dataops"
+  },
+  "config": {
+    "version": "2.0",
+    "logicalId": "87aa20c9-1da7-4497-9a23-501c2f05a4aa"
+  }
+}

--- a/projects/fabric/template/sandbox/dataops.Report/StaticResources/SharedResources/BaseThemes/CY26SU02.json
+++ b/projects/fabric/template/sandbox/dataops.Report/StaticResources/SharedResources/BaseThemes/CY26SU02.json
@@ -1,0 +1,941 @@
+{
+  "name": "CY26SU02",
+  "dataColors": [
+    "#118DFF",
+    "#12239E",
+    "#E66C37",
+    "#6B007B",
+    "#E044A7",
+    "#744EC2",
+    "#D9B300",
+    "#D64550",
+    "#197278",
+    "#1AAB40",
+    "#15C6F4",
+    "#4092FF",
+    "#FFA058",
+    "#BE5DC9",
+    "#F472D0",
+    "#B5A1FF",
+    "#C4A200",
+    "#FF8080",
+    "#00DBBC",
+    "#5BD667",
+    "#0091D5",
+    "#4668C5",
+    "#FF6300",
+    "#99008A",
+    "#EC008C",
+    "#533285",
+    "#99700A",
+    "#FF4141",
+    "#1F9A85",
+    "#25891C",
+    "#0057A2",
+    "#002050",
+    "#C94F0F",
+    "#450F54",
+    "#B60064",
+    "#34124F",
+    "#6A5A29",
+    "#1AAB40",
+    "#BA141A",
+    "#0C3D37",
+    "#0B511F"
+  ],
+  "foreground": "#252423",
+  "foregroundNeutralSecondary": "#605E5C",
+  "foregroundNeutralTertiary": "#B3B0AD",
+  "background": "#FFFFFF",
+  "backgroundLight": "#F3F2F1",
+  "backgroundNeutral": "#C8C6C4",
+  "tableAccent": "#118DFF",
+  "good": "#1AAB40",
+  "neutral": "#D9B300",
+  "bad": "#D64554",
+  "maximum": "#118DFF",
+  "center": "#D9B300",
+  "minimum": "#DEEFFF",
+  "null": "#FF7F48",
+  "hyperlink": "#0078d4",
+  "visitedHyperlink": "#0078d4",
+  "textClasses": {
+    "callout": {
+      "fontSize": 24,
+      "fontFace": "DIN",
+      "color": "#252423"
+    },
+    "title": {
+      "fontSize": 12,
+      "fontFace": "DIN",
+      "color": "#252423"
+    },
+    "header": {
+      "fontSize": 12,
+      "fontFace": "Segoe UI Semibold",
+      "color": "#252423"
+    },
+    "label": {
+      "fontSize": 10,
+      "fontFace": "Segoe UI",
+      "color": "#252423"
+    }
+  },
+  "visualStyles": {
+    "*": {
+      "*": {
+        "*": [
+          {
+            "wordWrap": true
+          }
+        ],
+        "line": [
+          {
+            "transparency": 0
+          }
+        ],
+        "outline": [
+          {
+            "transparency": 0
+          }
+        ],
+        "plotArea": [
+          {
+            "transparency": 0
+          }
+        ],
+        "categoryAxis": [
+          {
+            "showAxisTitle": true,
+            "gridlineStyle": "dotted",
+            "concatenateLabels": false
+          }
+        ],
+        "valueAxis": [
+          {
+            "showAxisTitle": true,
+            "gridlineStyle": "dotted"
+          }
+        ],
+        "y2Axis": [
+          {
+            "show": true
+          }
+        ],
+        "title": [
+          {
+            "titleWrap": true
+          }
+        ],
+        "lineStyles": [
+          {
+            "strokeWidth": 3
+          }
+        ],
+        "wordWrap": [
+          {
+            "show": true
+          }
+        ],
+        "background": [
+          {
+            "show": true,
+            "transparency": 0
+          }
+        ],
+        "border": [
+          {
+            "width": 1
+          }
+        ],
+        "outspacePane": [
+          {
+            "backgroundColor": {
+              "solid": {
+                "color": "#ffffff"
+              }
+            },
+            "transparency": 0,
+            "border": true,
+            "borderColor": {
+              "solid": {
+                "color": "#B3B0AD"
+              }
+            }
+          }
+        ],
+        "filterCard": [
+          {
+            "$id": "Applied",
+            "transparency": 0,
+            "foregroundColor": {
+              "solid": {
+                "color": "#252423"
+              }
+            },
+            "border": true
+          },
+          {
+            "$id": "Available",
+            "transparency": 0,
+            "foregroundColor": {
+              "solid": {
+                "color": "#252423"
+              }
+            },
+            "border": true
+          }
+        ]
+      }
+    },
+    "scatterChart": {
+      "*": {
+        "bubbles": [
+          {
+            "bubbleSize": -10,
+            "markerRangeType": "auto"
+          }
+        ],
+        "general": [
+          {
+            "responsive": true
+          }
+        ],
+        "fillPoint": [
+          {
+            "show": true
+          }
+        ],
+        "legend": [
+          {
+            "showGradientLegend": true
+          }
+        ]
+      }
+    },
+    "lineChart": {
+      "*": {
+        "general": [
+          {
+            "responsive": true
+          }
+        ],
+        "smallMultiplesLayout": [
+          {
+            "backgroundTransparency": 0,
+            "gridLineType": "inner"
+          }
+        ],
+        "forecast": [
+          {
+            "matchSeriesInterpolation": true
+          }
+        ]
+      }
+    },
+    "map": {
+      "*": {
+        "bubbles": [
+          {
+            "bubbleSize": -10,
+            "markerRangeType": "auto"
+          }
+        ]
+      }
+    },
+    "azureMap": {
+      "*": {
+        "bubbleLayer": [
+          {
+            "bubbleRadius": 8,
+            "minBubbleRadius": 8,
+            "maxRadius": 40
+          }
+        ],
+        "barChart": [
+          {
+            "barHeight": 3,
+            "thickness": 3
+          }
+        ]
+      }
+    },
+    "pieChart": {
+      "*": {
+        "legend": [
+          {
+            "show": true,
+            "position": "RightCenter"
+          }
+        ],
+        "labels": [
+          {
+            "labelStyle": "Data value, percent of total"
+          }
+        ]
+      }
+    },
+    "donutChart": {
+      "*": {
+        "legend": [
+          {
+            "show": true,
+            "position": "RightCenter"
+          }
+        ],
+        "labels": [
+          {
+            "labelStyle": "Data value, percent of total"
+          }
+        ]
+      }
+    },
+    "pivotTable": {
+      "*": {
+        "rowHeaders": [
+          {
+            "showExpandCollapseButtons": true,
+            "legacyStyleDisabled": true
+          }
+        ]
+      }
+    },
+    "multiRowCard": {
+      "*": {
+        "card": [
+          {
+            "outlineWeight": 2,
+            "barShow": true,
+            "barWeight": 2
+          }
+        ]
+      }
+    },
+    "kpi": {
+      "*": {
+        "trendline": [
+          {
+            "transparency": 20
+          }
+        ]
+      }
+    },
+    "cardVisual": {
+      "*": {
+        "layout": [
+          {
+            "maxTiles": 3
+          },
+          {
+            "$id": "default",
+            "cellPadding": 12,
+            "paddingIndividual": false,
+            "paddingUniform": 12,
+            "backgroundShow": true
+          }
+        ],
+        "overflow": [
+          {
+            "type": 0
+          }
+        ],
+        "image": [
+          {
+            "$id": "default",
+            "position": "Left",
+            "imageAreaSize": 20,
+            "padding": 12,
+            "rectangleRoundedCurve": 4,
+            "fit": "Normal",
+            "fixedSize": false
+          }
+        ],
+        "referenceLabel": [
+          {
+            "$id": "default",
+            "backgroundColor": {
+              "solid": {
+                "color": "backgroundLight"
+              }
+            },
+            "paddingUniform": 12,
+            "rectangleRoundedCurveCustomStyle": true,
+            "rectangleRoundedCurveLeftBottom": 4,
+            "rectangleRoundedCurveRightBottom": 4
+          }
+        ],
+        "referenceLabelDetail": [
+          {
+            "$id": "default",
+            "detailBackgroundColor": {
+              "solid": {
+                "color": "foreground"
+              }
+            },
+            "detailFontColor": {
+              "solid": {
+                "color": "background"
+              }
+            }
+          }
+        ],
+        "referenceLabelTitle": [
+          {
+            "$id": "default",
+            "titleFontColor": {
+              "solid": {
+                "color": "foregroundNeutralSecondary"
+              }
+            }
+          }
+        ],
+        "referenceLabelValue": [
+          {
+            "$id": "default",
+            "valueFontFamily": "'Segoe UI Semibold', wf_segoe-ui_semibold, helvetica, arial, sans-serif",
+            "fontColor": {
+              "solid": {
+                "color": "foreground"
+              }
+            }
+          }
+        ],
+        "value": [
+          {
+            "$id": "default",
+            "fontFamily": "'Segoe UI Semibold', wf_segoe-ui_semibold, helvetica, arial, sans-serif"
+          }
+        ],
+        "label": [
+          {
+            "$id": "default",
+            "position": "belowValue",
+            "fontColor": {
+              "solid": {
+                "color": "foregroundNeutralSecondary"
+              }
+            }
+          }
+        ],
+        "spacing": [
+          {
+            "$id": "default",
+            "verticalSpacing": 2
+          }
+        ],
+        "outline": [
+          {
+            "$id": "default",
+            "lineColor": {
+              "solid": {
+                "color": "backgroundLight"
+              }
+            }
+          }
+        ],
+        "divider": [
+          {
+            "$id": "default",
+            "dividerColor": {
+              "solid": {
+                "color": "backgroundLight"
+              }
+            }
+          }
+        ],
+        "shapeCustomRectangle": [
+          {
+            "$id": "default",
+            "tileShape": "rectangleRoundedByPixel",
+            "rectangleRoundedCurve": 4
+          }
+        ],
+        "smallMultiplesOuterShape": [
+          {
+            "$id": "default",
+            "rectangleRoundedCurveCustomStyle": false,
+            "rectangleRoundedCurve": 4
+          }
+        ],
+        "smallMultiplesHeader": [
+          {
+            "$id": "default",
+            "paddingIndividual": false,
+            "paddingUniform": 12,
+            "backgroundColor": {
+              "solid": {
+                "color": "backgroundLight"
+              }
+            }
+          }
+        ],
+        "smallMultiplesLayout": [
+          {
+            "style": "Table",
+            "cellPadding": 12,
+            "rowCount": 3,
+            "orientation": 1,
+            "titleOrientation": 1,
+            "headerPosition": "Top"
+          }
+        ],
+        "smallMultiplesGrid": [
+          {
+            "gridlineColor": {
+              "solid": {
+                "color": "foregroundNeutralTertiary"
+              }
+            }
+          }
+        ],
+        "smallMultiplesBorder": [
+          {
+            "$id": "default",
+            "gridlineColor": {
+              "solid": {
+                "color": "foregroundNeutralTertiary"
+              }
+            }
+          }
+        ],
+        "padding": [
+          {
+            "$id": "default",
+            "paddingUniform": 12,
+            "paddingIndividual": false
+          }
+        ]
+      }
+    },
+    "advancedSlicerVisual": {
+      "*": {
+        "layout": [
+          {
+            "maxTiles": 3
+          }
+        ],
+        "shapeCustomRectangle": [
+          {
+            "$id": "default",
+            "tileShape": "rectangleRoundedByPixel",
+            "rectangleRoundedCurve": 4
+          }
+        ],
+        "selectionIcon": [
+          {
+            "$id": "default",
+            "size": 12
+          }
+        ],
+        "value": [
+          {
+            "$id": "default",
+            "fontFamily": "'''Segoe UI Semibold'', wf_segoe-ui_semibold, helvetica, arial, sans-serif'"
+          }
+        ]
+      }
+    },
+    "slicer": {
+      "*": {
+        "general": [
+          {
+            "responsive": true
+          }
+        ],
+        "date": [
+          {
+            "hideDatePickerButton": false
+          }
+        ],
+        "items": [
+          {
+            "padding": 4,
+            "accessibilityContrastProperties": true
+          }
+        ]
+      }
+    },
+    "waterfallChart": {
+      "*": {
+        "general": [
+          {
+            "responsive": true
+          }
+        ]
+      }
+    },
+    "columnChart": {
+      "*": {
+        "general": [
+          {
+            "responsive": true
+          }
+        ],
+        "legend": [
+          {
+            "showGradientLegend": true
+          }
+        ],
+        "smallMultiplesLayout": [
+          {
+            "backgroundTransparency": 0,
+            "gridLineType": "inner"
+          }
+        ]
+      }
+    },
+    "clusteredColumnChart": {
+      "*": {
+        "general": [
+          {
+            "responsive": true
+          }
+        ],
+        "legend": [
+          {
+            "showGradientLegend": true
+          }
+        ],
+        "smallMultiplesLayout": [
+          {
+            "backgroundTransparency": 0,
+            "gridLineType": "inner"
+          }
+        ]
+      }
+    },
+    "hundredPercentStackedColumnChart": {
+      "*": {
+        "general": [
+          {
+            "responsive": true
+          }
+        ],
+        "legend": [
+          {
+            "showGradientLegend": true
+          }
+        ],
+        "smallMultiplesLayout": [
+          {
+            "backgroundTransparency": 0,
+            "gridLineType": "inner"
+          }
+        ]
+      }
+    },
+    "barChart": {
+      "*": {
+        "general": [
+          {
+            "responsive": true
+          }
+        ],
+        "legend": [
+          {
+            "showGradientLegend": true
+          }
+        ],
+        "smallMultiplesLayout": [
+          {
+            "backgroundTransparency": 0,
+            "gridLineType": "inner"
+          }
+        ]
+      }
+    },
+    "clusteredBarChart": {
+      "*": {
+        "general": [
+          {
+            "responsive": true
+          }
+        ],
+        "legend": [
+          {
+            "showGradientLegend": true
+          }
+        ],
+        "smallMultiplesLayout": [
+          {
+            "backgroundTransparency": 0,
+            "gridLineType": "inner"
+          }
+        ]
+      }
+    },
+    "hundredPercentStackedBarChart": {
+      "*": {
+        "general": [
+          {
+            "responsive": true
+          }
+        ],
+        "legend": [
+          {
+            "showGradientLegend": true
+          }
+        ],
+        "smallMultiplesLayout": [
+          {
+            "backgroundTransparency": 0,
+            "gridLineType": "inner"
+          }
+        ]
+      }
+    },
+    "areaChart": {
+      "*": {
+        "general": [
+          {
+            "responsive": true
+          }
+        ],
+        "smallMultiplesLayout": [
+          {
+            "backgroundTransparency": 0,
+            "gridLineType": "inner"
+          }
+        ]
+      }
+    },
+    "stackedAreaChart": {
+      "*": {
+        "general": [
+          {
+            "responsive": true
+          }
+        ],
+        "smallMultiplesLayout": [
+          {
+            "backgroundTransparency": 0,
+            "gridLineType": "inner"
+          }
+        ]
+      }
+    },
+    "lineClusteredColumnComboChart": {
+      "*": {
+        "general": [
+          {
+            "responsive": true
+          }
+        ],
+        "smallMultiplesLayout": [
+          {
+            "backgroundTransparency": 0,
+            "gridLineType": "inner"
+          }
+        ],
+        "seriesLabels": [
+          {
+            "backgroundTransparency": 0.9
+          }
+        ]
+      }
+    },
+    "lineStackedColumnComboChart": {
+      "*": {
+        "general": [
+          {
+            "responsive": true
+          }
+        ],
+        "smallMultiplesLayout": [
+          {
+            "backgroundTransparency": 0,
+            "gridLineType": "inner"
+          }
+        ],
+        "seriesLabels": [
+          {
+            "backgroundTransparency": 0.9
+          }
+        ]
+      }
+    },
+    "ribbonChart": {
+      "*": {
+        "general": [
+          {
+            "responsive": true
+          }
+        ],
+        "smallMultiplesLayout": [
+          {
+            "backgroundTransparency": 0,
+            "gridLineType": "inner"
+          }
+        ],
+        "valueAxis": [
+          {
+            "show": true
+          }
+        ]
+      }
+    },
+    "hundredPercentStackedAreaChart": {
+      "*": {
+        "general": [
+          {
+            "responsive": true
+          }
+        ],
+        "smallMultiplesLayout": [
+          {
+            "backgroundTransparency": 0,
+            "gridLineType": "inner"
+          }
+        ]
+      }
+    },
+    "group": {
+      "*": {
+        "background": [
+          {
+            "show": false
+          }
+        ]
+      }
+    },
+    "basicShape": {
+      "*": {
+        "background": [
+          {
+            "show": false
+          }
+        ],
+        "general": [
+          {
+            "keepLayerOrder": true
+          }
+        ],
+        "visualHeader": [
+          {
+            "show": false
+          }
+        ]
+      }
+    },
+    "shape": {
+      "*": {
+        "background": [
+          {
+            "show": false
+          }
+        ],
+        "general": [
+          {
+            "keepLayerOrder": true
+          }
+        ],
+        "visualHeader": [
+          {
+            "show": false
+          }
+        ]
+      }
+    },
+    "image": {
+      "*": {
+        "background": [
+          {
+            "show": false
+          }
+        ],
+        "general": [
+          {
+            "keepLayerOrder": true
+          }
+        ],
+        "visualHeader": [
+          {
+            "show": false
+          }
+        ],
+        "padding": [
+          {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        ]
+      }
+    },
+    "actionButton": {
+      "*": {
+        "background": [
+          {
+            "show": false
+          }
+        ],
+        "visualHeader": [
+          {
+            "show": false
+          }
+        ]
+      }
+    },
+    "pageNavigator": {
+      "*": {
+        "background": [
+          {
+            "show": false
+          }
+        ],
+        "visualHeader": [
+          {
+            "show": false
+          }
+        ]
+      }
+    },
+    "bookmarkNavigator": {
+      "*": {
+        "background": [
+          {
+            "show": false
+          }
+        ],
+        "visualHeader": [
+          {
+            "show": false
+          }
+        ]
+      }
+    },
+    "textbox": {
+      "*": {
+        "general": [
+          {
+            "keepLayerOrder": true
+          }
+        ],
+        "visualHeader": [
+          {
+            "show": false
+          }
+        ]
+      }
+    },
+    "page": {
+      "*": {
+        "outspace": [
+          {
+            "color": {
+              "solid": {
+                "color": "#FFFFFF"
+              }
+            }
+          }
+        ],
+        "background": [
+          {
+            "transparency": 100
+          }
+        ]
+      }
+    }
+  }
+}

--- a/projects/fabric/template/sandbox/dataops.Report/definition.pbir
+++ b/projects/fabric/template/sandbox/dataops.Report/definition.pbir
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definitionProperties/2.0.0/schema.json",
+  "version": "4.0",
+  "datasetReference": {
+    "byPath": {
+      "path": "../dataops.SemanticModel"
+    }
+  }
+}

--- a/projects/fabric/template/sandbox/dataops.Report/definition/pages/85e27d67efd2bef4072d/page.json
+++ b/projects/fabric/template/sandbox/dataops.Report/definition/pages/85e27d67efd2bef4072d/page.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/page/2.1.0/schema.json",
+  "name": "85e27d67efd2bef4072d",
+  "displayName": "Delta Tables & Commits",
+  "displayOption": "FitToPage",
+  "height": 720,
+  "width": 1280
+}

--- a/projects/fabric/template/sandbox/dataops.Report/definition/pages/85e27d67efd2bef4072d/visuals/03d84585e2e414aa3028/visual.json
+++ b/projects/fabric/template/sandbox/dataops.Report/definition/pages/85e27d67efd2bef4072d/visuals/03d84585e2e414aa3028/visual.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.7.0/schema.json",
+  "name": "03d84585e2e414aa3028",
+  "position": {
+    "x": 632,
+    "y": 64,
+    "z": 2200,
+    "height": 92,
+    "width": 300,
+    "tabOrder": 2200
+  },
+  "visual": {
+    "visualType": "multiRowCard",
+    "query": {
+      "queryState": {
+        "Values": {
+          "projections": [
+            {
+              "field": {
+                "Measure": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "fct_delta_storage"
+                    }
+                  },
+                  "Property": "Latest Storage (GB)"
+                }
+              },
+              "queryRef": "fct_delta_storage.Latest Storage (GB)",
+              "nativeQueryRef": "Latest Storage (GB)"
+            }
+          ]
+        }
+      }
+    },
+    "objects": {
+      "card": [
+        {
+          "properties": {
+            "barColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 2,
+                      "Percent": 0
+                    }
+                  }
+                }
+              }
+            },
+            "barWeight": {
+              "expr": {
+                "Literal": {
+                  "Value": "4L"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "dataLabels": [
+        {
+          "properties": {
+            "fontFamily": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Segoe UI'"
+                }
+              }
+            },
+            "fontSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "11L"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "categoryLabels": [
+        {
+          "properties": {
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 1,
+                      "Percent": 0.4
+                    }
+                  }
+                }
+              }
+            },
+            "fontSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "11L"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "visualContainerObjects": {
+      "visualHeader": [
+        {
+          "properties": {
+            "showCopyVisualImageButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFilterRestatementButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFocusModeButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showPinButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showPersonalizeVisualButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/projects/fabric/template/sandbox/dataops.Report/definition/pages/85e27d67efd2bef4072d/visuals/05e117d1075d8d0f4e57/visual.json
+++ b/projects/fabric/template/sandbox/dataops.Report/definition/pages/85e27d67efd2bef4072d/visuals/05e117d1075d8d0f4e57/visual.json
@@ -1,0 +1,177 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.7.0/schema.json",
+  "name": "05e117d1075d8d0f4e57",
+  "position": {
+    "x": 424,
+    "y": 430,
+    "z": 4100,
+    "height": 274,
+    "width": 420,
+    "tabOrder": 4100
+  },
+  "visual": {
+    "visualType": "lineChart",
+    "query": {
+      "queryState": {
+        "Category": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "dim_date"
+                    }
+                  },
+                  "Property": "full_date"
+                }
+              },
+              "queryRef": "dim_date.full_date",
+              "nativeQueryRef": "full_date",
+              "active": true
+            }
+          ]
+        },
+        "Y": {
+          "projections": [
+            {
+              "field": {
+                "Measure": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "fct_delta_storage"
+                    }
+                  },
+                  "Property": "Total Storage (GB)"
+                }
+              },
+              "queryRef": "fct_delta_storage.Total Storage (GB)",
+              "nativeQueryRef": "Total Storage (GB)"
+            }
+          ]
+        },
+        "Series": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "dim_delta_table"
+                    }
+                  },
+                  "Property": "table_fqn"
+                }
+              },
+              "queryRef": "dim_delta_table.table_fqn",
+              "nativeQueryRef": "table_fqn"
+            }
+          ]
+        }
+      },
+      "sortDefinition": {
+        "sort": [
+          {
+            "field": {
+              "Column": {
+                "Expression": {
+                  "SourceRef": {
+                    "Entity": "dim_date"
+                  }
+                },
+                "Property": "full_date"
+              }
+            },
+            "direction": "Ascending"
+          }
+        ],
+        "isDefaultSort": true
+      }
+    },
+    "objects": {
+      "title": [
+        {
+          "properties": {
+            "text": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Largest Tables Size in GB over Time'"
+                }
+              }
+            },
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "categoryAxis": [
+        {
+          "properties": {
+            "axisType": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Categorical'"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "labels": [
+        {
+          "properties": {
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "visualContainerObjects": {
+      "visualHeader": [
+        {
+          "properties": {
+            "showCopyVisualImageButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFilterRestatementButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFocusModeButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showPinButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/projects/fabric/template/sandbox/dataops.Report/definition/pages/85e27d67efd2bef4072d/visuals/17220e549491cd7444ff/visual.json
+++ b/projects/fabric/template/sandbox/dataops.Report/definition/pages/85e27d67efd2bef4072d/visuals/17220e549491cd7444ff/visual.json
@@ -1,0 +1,175 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.7.0/schema.json",
+  "name": "17220e549491cd7444ff",
+  "position": {
+    "x": 16,
+    "y": 168,
+    "z": 3000,
+    "height": 250,
+    "width": 620,
+    "tabOrder": 3000
+  },
+  "visual": {
+    "visualType": "clusteredColumnChart",
+    "query": {
+      "queryState": {
+        "Category": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "dim_date"
+                    }
+                  },
+                  "Property": "full_date"
+                }
+              },
+              "queryRef": "dim_date.full_date",
+              "nativeQueryRef": "full_date",
+              "active": true
+            }
+          ]
+        },
+        "Y": {
+          "projections": [
+            {
+              "field": {
+                "Measure": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "fct_delta_commit"
+                    }
+                  },
+                  "Property": "Total Commits"
+                }
+              },
+              "queryRef": "fct_delta_commit.Total Commits",
+              "nativeQueryRef": "Total Commits"
+            }
+          ]
+        },
+        "Series": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "dim_delta_table_operation_type"
+                    }
+                  },
+                  "Property": "operation"
+                }
+              },
+              "queryRef": "dim_delta_table_operation_type.operation",
+              "nativeQueryRef": "operation"
+            }
+          ]
+        }
+      },
+      "sortDefinition": {
+        "sort": [
+          {
+            "field": {
+              "Column": {
+                "Expression": {
+                  "SourceRef": {
+                    "Entity": "dim_date"
+                  }
+                },
+                "Property": "full_date"
+              }
+            },
+            "direction": "Ascending"
+          }
+        ],
+        "isDefaultSort": true
+      }
+    },
+    "objects": {
+      "categoryAxis": [
+        {
+          "properties": {
+            "axisType": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Categorical'"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "labels": [
+        {
+          "properties": {
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "dataPoint": [
+        {
+          "properties": {
+            "fill": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 3,
+                      "Percent": 0
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "visualContainerObjects": {
+      "visualHeader": [
+        {
+          "properties": {
+            "showCopyVisualImageButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFilterRestatementButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFocusModeButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showPinButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/projects/fabric/template/sandbox/dataops.Report/definition/pages/85e27d67efd2bef4072d/visuals/1d8cf8c0f357c22cc2d0/visual.json
+++ b/projects/fabric/template/sandbox/dataops.Report/definition/pages/85e27d67efd2bef4072d/visuals/1d8cf8c0f357c22cc2d0/visual.json
@@ -1,0 +1,235 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.7.0/schema.json",
+  "name": "1d8cf8c0f357c22cc2d0",
+  "position": {
+    "x": 856,
+    "y": 430,
+    "z": 4200,
+    "height": 274,
+    "width": 408,
+    "tabOrder": 4200
+  },
+  "filterConfig": {
+    "filters": [
+      {
+        "name": "ff5168029195402698c96741bba7e537",
+        "field": {
+          "Column": {
+            "Expression": {
+              "SourceRef": {
+                "Entity": "dim_delta_table_health_status"
+              }
+            },
+            "Property": "status"
+          }
+        },
+        "type": "Categorical",
+        "filter": {
+          "Version": 2,
+          "From": [
+            {
+              "Name": "h",
+              "Entity": "dim_delta_table_health_status",
+              "Type": 0
+            }
+          ],
+          "Where": [
+            {
+              "Condition": {
+                "In": {
+                  "Expressions": [
+                    {
+                      "Column": {
+                        "Expression": {
+                          "SourceRef": {
+                            "Source": "h"
+                          }
+                        },
+                        "Property": "status"
+                      }
+                    }
+                  ],
+                  "Values": [
+                    [
+                      {
+                        "Literal": {
+                          "Value": "'Unhealthy'"
+                        }
+                      }
+                    ]
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "displayName": "Health status"
+      }
+    ]
+  },
+  "visual": {
+    "visualType": "lineChart",
+    "query": {
+      "queryState": {
+        "Category": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "dim_date"
+                    }
+                  },
+                  "Property": "full_date"
+                }
+              },
+              "queryRef": "dim_date.full_date",
+              "nativeQueryRef": "full_date",
+              "active": true
+            }
+          ]
+        },
+        "Y": {
+          "projections": [
+            {
+              "field": {
+                "Measure": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "fct_delta_health"
+                    }
+                  },
+                  "Property": "Avg Days Since Last Commit"
+                }
+              },
+              "queryRef": "fct_delta_health.Avg Days Since Last Commit",
+              "nativeQueryRef": "Avg Days Since Last Commit"
+            }
+          ]
+        },
+        "Series": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "dim_delta_table"
+                    }
+                  },
+                  "Property": "table_fqn"
+                }
+              },
+              "queryRef": "dim_delta_table.table_fqn",
+              "nativeQueryRef": "table_fqn"
+            }
+          ]
+        }
+      },
+      "sortDefinition": {
+        "sort": [
+          {
+            "field": {
+              "Column": {
+                "Expression": {
+                  "SourceRef": {
+                    "Entity": "dim_date"
+                  }
+                },
+                "Property": "full_date"
+              }
+            },
+            "direction": "Ascending"
+          }
+        ],
+        "isDefaultSort": true
+      }
+    },
+    "objects": {
+      "title": [
+        {
+          "properties": {
+            "text": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Unhealthy Tables: Days Since Last Commit'"
+                }
+              }
+            },
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "categoryAxis": [
+        {
+          "properties": {
+            "axisType": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Categorical'"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "labels": [
+        {
+          "properties": {
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "visualContainerObjects": {
+      "visualHeader": [
+        {
+          "properties": {
+            "showCopyVisualImageButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFilterRestatementButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFocusModeButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showPinButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/projects/fabric/template/sandbox/dataops.Report/definition/pages/85e27d67efd2bef4072d/visuals/20d424b4c74383c4c136/visual.json
+++ b/projects/fabric/template/sandbox/dataops.Report/definition/pages/85e27d67efd2bef4072d/visuals/20d424b4c74383c4c136/visual.json
@@ -1,0 +1,157 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.7.0/schema.json",
+  "name": "20d424b4c74383c4c136",
+  "position": {
+    "x": 648,
+    "y": 168,
+    "z": 3100,
+    "height": 250,
+    "width": 616,
+    "tabOrder": 3100
+  },
+  "visual": {
+    "visualType": "lineChart",
+    "query": {
+      "queryState": {
+        "Category": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "dim_date"
+                    }
+                  },
+                  "Property": "full_date"
+                }
+              },
+              "queryRef": "dim_date.full_date",
+              "nativeQueryRef": "full_date",
+              "active": true
+            }
+          ]
+        },
+        "Y": {
+          "projections": [
+            {
+              "field": {
+                "Measure": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "fct_delta_storage"
+                    }
+                  },
+                  "Property": "Total Storage (GB)"
+                }
+              },
+              "queryRef": "fct_delta_storage.Total Storage (GB)",
+              "nativeQueryRef": "Total Storage (GB)"
+            }
+          ]
+        }
+      },
+      "sortDefinition": {
+        "sort": [
+          {
+            "field": {
+              "Column": {
+                "Expression": {
+                  "SourceRef": {
+                    "Entity": "dim_date"
+                  }
+                },
+                "Property": "full_date"
+              }
+            },
+            "direction": "Ascending"
+          }
+        ],
+        "isDefaultSort": true
+      }
+    },
+    "objects": {
+      "categoryAxis": [
+        {
+          "properties": {
+            "axisType": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Categorical'"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "labels": [
+        {
+          "properties": {
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "dataPoint": [
+        {
+          "properties": {
+            "fill": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 3,
+                      "Percent": 0
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "visualContainerObjects": {
+      "visualHeader": [
+        {
+          "properties": {
+            "showCopyVisualImageButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFilterRestatementButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFocusModeButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showPinButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/projects/fabric/template/sandbox/dataops.Report/definition/pages/85e27d67efd2bef4072d/visuals/4b49b56798950adebfc3/visual.json
+++ b/projects/fabric/template/sandbox/dataops.Report/definition/pages/85e27d67efd2bef4072d/visuals/4b49b56798950adebfc3/visual.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.7.0/schema.json",
+  "name": "4b49b56798950adebfc3",
+  "position": {
+    "x": 940,
+    "y": 64,
+    "z": 2300,
+    "height": 92,
+    "width": 308,
+    "tabOrder": 2300
+  },
+  "visual": {
+    "visualType": "multiRowCard",
+    "query": {
+      "queryState": {
+        "Values": {
+          "projections": [
+            {
+              "field": {
+                "Measure": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "fct_delta_health"
+                    }
+                  },
+                  "Property": "Healthy Table %"
+                }
+              },
+              "queryRef": "fct_delta_health.Healthy Table %",
+              "nativeQueryRef": "Healthy Table %"
+            }
+          ]
+        }
+      }
+    },
+    "objects": {
+      "card": [
+        {
+          "properties": {
+            "barColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 2,
+                      "Percent": 0
+                    }
+                  }
+                }
+              }
+            },
+            "barWeight": {
+              "expr": {
+                "Literal": {
+                  "Value": "4L"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "dataLabels": [
+        {
+          "properties": {
+            "fontFamily": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Segoe UI'"
+                }
+              }
+            },
+            "fontSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "11L"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "categoryLabels": [
+        {
+          "properties": {
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 1,
+                      "Percent": 0.4
+                    }
+                  }
+                }
+              }
+            },
+            "fontSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "11L"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "visualContainerObjects": {
+      "visualHeader": [
+        {
+          "properties": {
+            "showCopyVisualImageButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFilterRestatementButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFocusModeButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showPinButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showPersonalizeVisualButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/projects/fabric/template/sandbox/dataops.Report/definition/pages/85e27d67efd2bef4072d/visuals/64602968ddabc521b6c7/visual.json
+++ b/projects/fabric/template/sandbox/dataops.Report/definition/pages/85e27d67efd2bef4072d/visuals/64602968ddabc521b6c7/visual.json
@@ -1,0 +1,175 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.7.0/schema.json",
+  "name": "64602968ddabc521b6c7",
+  "position": {
+    "x": 16,
+    "y": 430,
+    "z": 4000,
+    "height": 274,
+    "width": 400,
+    "tabOrder": 4000
+  },
+  "visual": {
+    "visualType": "clusteredColumnChart",
+    "query": {
+      "queryState": {
+        "Category": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "dim_date"
+                    }
+                  },
+                  "Property": "full_date"
+                }
+              },
+              "queryRef": "dim_date.full_date",
+              "nativeQueryRef": "full_date",
+              "active": true
+            }
+          ]
+        },
+        "Y": {
+          "projections": [
+            {
+              "field": {
+                "Measure": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "fct_delta_health"
+                    }
+                  },
+                  "Property": "Health Assessments"
+                }
+              },
+              "queryRef": "fct_delta_health.Health Assessments",
+              "nativeQueryRef": "Health Assessments"
+            }
+          ]
+        },
+        "Series": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "dim_delta_table_health_status"
+                    }
+                  },
+                  "Property": "status"
+                }
+              },
+              "queryRef": "dim_delta_table_health_status.status",
+              "nativeQueryRef": "status"
+            }
+          ]
+        }
+      },
+      "sortDefinition": {
+        "sort": [
+          {
+            "field": {
+              "Column": {
+                "Expression": {
+                  "SourceRef": {
+                    "Entity": "dim_date"
+                  }
+                },
+                "Property": "full_date"
+              }
+            },
+            "direction": "Ascending"
+          }
+        ],
+        "isDefaultSort": true
+      }
+    },
+    "objects": {
+      "categoryAxis": [
+        {
+          "properties": {
+            "axisType": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Categorical'"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "labels": [
+        {
+          "properties": {
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "dataPoint": [
+        {
+          "properties": {
+            "fill": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 3,
+                      "Percent": 0
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "visualContainerObjects": {
+      "visualHeader": [
+        {
+          "properties": {
+            "showCopyVisualImageButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFilterRestatementButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFocusModeButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showPinButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/projects/fabric/template/sandbox/dataops.Report/definition/pages/85e27d67efd2bef4072d/visuals/7dfe2a838d2553279518/visual.json
+++ b/projects/fabric/template/sandbox/dataops.Report/definition/pages/85e27d67efd2bef4072d/visuals/7dfe2a838d2553279518/visual.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.7.0/schema.json",
+  "name": "7dfe2a838d2553279518",
+  "position": {
+    "x": 16,
+    "y": 64,
+    "z": 2000,
+    "height": 92,
+    "width": 300,
+    "tabOrder": 2000
+  },
+  "visual": {
+    "visualType": "multiRowCard",
+    "query": {
+      "queryState": {
+        "Values": {
+          "projections": [
+            {
+              "field": {
+                "Measure": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "fct_delta_commit"
+                    }
+                  },
+                  "Property": "Total Commits"
+                }
+              },
+              "queryRef": "fct_delta_commit.Total Commits",
+              "nativeQueryRef": "Total Commits"
+            }
+          ]
+        }
+      }
+    },
+    "objects": {
+      "card": [
+        {
+          "properties": {
+            "barColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 2,
+                      "Percent": 0
+                    }
+                  }
+                }
+              }
+            },
+            "barWeight": {
+              "expr": {
+                "Literal": {
+                  "Value": "4L"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "dataLabels": [
+        {
+          "properties": {
+            "fontFamily": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Segoe UI'"
+                }
+              }
+            },
+            "fontSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "11L"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "categoryLabels": [
+        {
+          "properties": {
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 1,
+                      "Percent": 0.4
+                    }
+                  }
+                }
+              }
+            },
+            "fontSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "11L"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "visualContainerObjects": {
+      "visualHeader": [
+        {
+          "properties": {
+            "showCopyVisualImageButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFilterRestatementButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFocusModeButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showPinButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showPersonalizeVisualButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/projects/fabric/template/sandbox/dataops.Report/definition/pages/85e27d67efd2bef4072d/visuals/cc29b7c519f7c73c312e/visual.json
+++ b/projects/fabric/template/sandbox/dataops.Report/definition/pages/85e27d67efd2bef4072d/visuals/cc29b7c519f7c73c312e/visual.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.7.0/schema.json",
+  "name": "cc29b7c519f7c73c312e",
+  "position": {
+    "x": 16,
+    "y": 12,
+    "z": 1000,
+    "height": 40,
+    "width": 1248,
+    "tabOrder": 1000
+  },
+  "visual": {
+    "visualType": "textbox",
+    "objects": {
+      "general": [
+        {
+          "properties": {
+            "paragraphs": [
+              {
+                "textRuns": [
+                  {
+                    "value": "Delta Tables & Commits",
+                    "textStyle": {
+                      "fontSize": "20pt",
+                      "color": "#252423"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/projects/fabric/template/sandbox/dataops.Report/definition/pages/85e27d67efd2bef4072d/visuals/f9863187623243bd9d83/visual.json
+++ b/projects/fabric/template/sandbox/dataops.Report/definition/pages/85e27d67efd2bef4072d/visuals/f9863187623243bd9d83/visual.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.7.0/schema.json",
+  "name": "f9863187623243bd9d83",
+  "position": {
+    "x": 324,
+    "y": 64,
+    "z": 2100,
+    "height": 92,
+    "width": 300,
+    "tabOrder": 2100
+  },
+  "visual": {
+    "visualType": "multiRowCard",
+    "query": {
+      "queryState": {
+        "Values": {
+          "projections": [
+            {
+              "field": {
+                "Measure": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "fct_delta_commit"
+                    }
+                  },
+                  "Property": "Tables Tracked"
+                }
+              },
+              "queryRef": "fct_delta_commit.Tables Tracked",
+              "nativeQueryRef": "Tables Tracked"
+            }
+          ]
+        }
+      }
+    },
+    "objects": {
+      "card": [
+        {
+          "properties": {
+            "barColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 2,
+                      "Percent": 0
+                    }
+                  }
+                }
+              }
+            },
+            "barWeight": {
+              "expr": {
+                "Literal": {
+                  "Value": "4L"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "dataLabels": [
+        {
+          "properties": {
+            "fontFamily": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Segoe UI'"
+                }
+              }
+            },
+            "fontSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "11L"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "categoryLabels": [
+        {
+          "properties": {
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 1,
+                      "Percent": 0.4
+                    }
+                  }
+                }
+              }
+            },
+            "fontSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "11L"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "visualContainerObjects": {
+      "visualHeader": [
+        {
+          "properties": {
+            "showCopyVisualImageButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFilterRestatementButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFocusModeButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showPinButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showPersonalizeVisualButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/projects/fabric/template/sandbox/dataops.Report/definition/pages/d064789b4f2768213eb4/page.json
+++ b/projects/fabric/template/sandbox/dataops.Report/definition/pages/d064789b4f2768213eb4/page.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/page/2.1.0/schema.json",
+  "name": "d064789b4f2768213eb4",
+  "displayName": "dbt Pipeline Health",
+  "displayOption": "FitToPage",
+  "height": 720,
+  "width": 1280
+}

--- a/projects/fabric/template/sandbox/dataops.Report/definition/pages/d064789b4f2768213eb4/visuals/19d7b56a4b91f6d81c58/visual.json
+++ b/projects/fabric/template/sandbox/dataops.Report/definition/pages/d064789b4f2768213eb4/visuals/19d7b56a4b91f6d81c58/visual.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.7.0/schema.json",
+  "name": "19d7b56a4b91f6d81c58",
+  "position": {
+    "x": 16,
+    "y": 12,
+    "z": 1000,
+    "height": 40,
+    "width": 1248,
+    "tabOrder": 1000
+  },
+  "visual": {
+    "visualType": "textbox",
+    "objects": {
+      "general": [
+        {
+          "properties": {
+            "paragraphs": [
+              {
+                "textRuns": [
+                  {
+                    "value": "dbt Pipeline Health",
+                    "textStyle": {
+                      "fontSize": "20pt",
+                      "color": "#252423"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/projects/fabric/template/sandbox/dataops.Report/definition/pages/d064789b4f2768213eb4/visuals/38aa95791ccf969f4d8c/visual.json
+++ b/projects/fabric/template/sandbox/dataops.Report/definition/pages/d064789b4f2768213eb4/visuals/38aa95791ccf969f4d8c/visual.json
@@ -1,0 +1,177 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.7.0/schema.json",
+  "name": "38aa95791ccf969f4d8c",
+  "position": {
+    "x": 16,
+    "y": 430,
+    "z": 4000,
+    "height": 274,
+    "width": 620,
+    "tabOrder": 4000
+  },
+  "visual": {
+    "visualType": "lineChart",
+    "query": {
+      "queryState": {
+        "Category": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "dim_date"
+                    }
+                  },
+                  "Property": "full_date"
+                }
+              },
+              "queryRef": "dim_date.full_date",
+              "nativeQueryRef": "full_date",
+              "active": true
+            }
+          ]
+        },
+        "Y": {
+          "projections": [
+            {
+              "field": {
+                "Measure": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "fct_dbt_node_execution"
+                    }
+                  },
+                  "Property": "Total Execution Time (seconds)"
+                }
+              },
+              "queryRef": "fct_dbt_node_execution.Total Execution Time (seconds)",
+              "nativeQueryRef": "Total Execution Time (seconds)"
+            }
+          ]
+        },
+        "Series": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "dim_dbt_node"
+                    }
+                  },
+                  "Property": "node_name"
+                }
+              },
+              "queryRef": "dim_dbt_node.node_name",
+              "nativeQueryRef": "node_name"
+            }
+          ]
+        }
+      },
+      "sortDefinition": {
+        "sort": [
+          {
+            "field": {
+              "Column": {
+                "Expression": {
+                  "SourceRef": {
+                    "Entity": "dim_date"
+                  }
+                },
+                "Property": "full_date"
+              }
+            },
+            "direction": "Ascending"
+          }
+        ],
+        "isDefaultSort": true
+      }
+    },
+    "objects": {
+      "title": [
+        {
+          "properties": {
+            "text": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Slowest Models Execution Time over Time'"
+                }
+              }
+            },
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "categoryAxis": [
+        {
+          "properties": {
+            "axisType": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Categorical'"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "labels": [
+        {
+          "properties": {
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "visualContainerObjects": {
+      "visualHeader": [
+        {
+          "properties": {
+            "showCopyVisualImageButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFilterRestatementButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFocusModeButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showPinButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/projects/fabric/template/sandbox/dataops.Report/definition/pages/d064789b4f2768213eb4/visuals/40d6cde56437bbbdec5c/visual.json
+++ b/projects/fabric/template/sandbox/dataops.Report/definition/pages/d064789b4f2768213eb4/visuals/40d6cde56437bbbdec5c/visual.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.7.0/schema.json",
+  "name": "40d6cde56437bbbdec5c",
+  "position": {
+    "x": 16,
+    "y": 64,
+    "z": 2000,
+    "height": 92,
+    "width": 300,
+    "tabOrder": 2000
+  },
+  "visual": {
+    "visualType": "multiRowCard",
+    "query": {
+      "queryState": {
+        "Values": {
+          "projections": [
+            {
+              "field": {
+                "Measure": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "fct_dbt_node_execution"
+                    }
+                  },
+                  "Property": "Total Node Executions"
+                }
+              },
+              "queryRef": "fct_dbt_node_execution.Total Node Executions",
+              "nativeQueryRef": "Total Node Executions"
+            }
+          ]
+        }
+      }
+    },
+    "objects": {
+      "card": [
+        {
+          "properties": {
+            "barColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 2,
+                      "Percent": 0
+                    }
+                  }
+                }
+              }
+            },
+            "barWeight": {
+              "expr": {
+                "Literal": {
+                  "Value": "4L"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "dataLabels": [
+        {
+          "properties": {
+            "fontFamily": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Segoe UI'"
+                }
+              }
+            },
+            "fontSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "11L"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "categoryLabels": [
+        {
+          "properties": {
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 1,
+                      "Percent": 0.4
+                    }
+                  }
+                }
+              }
+            },
+            "fontSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "11L"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "visualContainerObjects": {
+      "visualHeader": [
+        {
+          "properties": {
+            "showCopyVisualImageButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFilterRestatementButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFocusModeButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showPinButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showPersonalizeVisualButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/projects/fabric/template/sandbox/dataops.Report/definition/pages/d064789b4f2768213eb4/visuals/417c6330494b543860ea/visual.json
+++ b/projects/fabric/template/sandbox/dataops.Report/definition/pages/d064789b4f2768213eb4/visuals/417c6330494b543860ea/visual.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.7.0/schema.json",
+  "name": "417c6330494b543860ea",
+  "position": {
+    "x": 940,
+    "y": 64,
+    "z": 2300,
+    "height": 92,
+    "width": 308,
+    "tabOrder": 2300
+  },
+  "visual": {
+    "visualType": "multiRowCard",
+    "query": {
+      "queryState": {
+        "Values": {
+          "projections": [
+            {
+              "field": {
+                "Measure": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "fct_dbt_node_execution"
+                    }
+                  },
+                  "Property": "Avg Execution Time (seconds)"
+                }
+              },
+              "queryRef": "fct_dbt_node_execution.Avg Execution Time (seconds)",
+              "nativeQueryRef": "Avg Execution Time (seconds)"
+            }
+          ]
+        }
+      }
+    },
+    "objects": {
+      "card": [
+        {
+          "properties": {
+            "barColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 2,
+                      "Percent": 0
+                    }
+                  }
+                }
+              }
+            },
+            "barWeight": {
+              "expr": {
+                "Literal": {
+                  "Value": "4L"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "dataLabels": [
+        {
+          "properties": {
+            "fontFamily": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Segoe UI'"
+                }
+              }
+            },
+            "fontSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "11L"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "categoryLabels": [
+        {
+          "properties": {
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 1,
+                      "Percent": 0.4
+                    }
+                  }
+                }
+              }
+            },
+            "fontSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "11L"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "visualContainerObjects": {
+      "visualHeader": [
+        {
+          "properties": {
+            "showCopyVisualImageButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFilterRestatementButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFocusModeButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showPinButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showPersonalizeVisualButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/projects/fabric/template/sandbox/dataops.Report/definition/pages/d064789b4f2768213eb4/visuals/72397ab63b59a53dfeb2/visual.json
+++ b/projects/fabric/template/sandbox/dataops.Report/definition/pages/d064789b4f2768213eb4/visuals/72397ab63b59a53dfeb2/visual.json
@@ -1,0 +1,175 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.7.0/schema.json",
+  "name": "72397ab63b59a53dfeb2",
+  "position": {
+    "x": 16,
+    "y": 168,
+    "z": 3000,
+    "height": 250,
+    "width": 620,
+    "tabOrder": 3000
+  },
+  "visual": {
+    "visualType": "clusteredColumnChart",
+    "query": {
+      "queryState": {
+        "Category": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "dim_date"
+                    }
+                  },
+                  "Property": "full_date"
+                }
+              },
+              "queryRef": "dim_date.full_date",
+              "nativeQueryRef": "full_date",
+              "active": true
+            }
+          ]
+        },
+        "Y": {
+          "projections": [
+            {
+              "field": {
+                "Measure": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "fct_dbt_node_execution"
+                    }
+                  },
+                  "Property": "Total Node Executions"
+                }
+              },
+              "queryRef": "fct_dbt_node_execution.Total Node Executions",
+              "nativeQueryRef": "Total Node Executions"
+            }
+          ]
+        },
+        "Series": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "dim_dbt_status"
+                    }
+                  },
+                  "Property": "status_group"
+                }
+              },
+              "queryRef": "dim_dbt_status.status_group",
+              "nativeQueryRef": "status_group"
+            }
+          ]
+        }
+      },
+      "sortDefinition": {
+        "sort": [
+          {
+            "field": {
+              "Column": {
+                "Expression": {
+                  "SourceRef": {
+                    "Entity": "dim_date"
+                  }
+                },
+                "Property": "full_date"
+              }
+            },
+            "direction": "Ascending"
+          }
+        ],
+        "isDefaultSort": true
+      }
+    },
+    "objects": {
+      "categoryAxis": [
+        {
+          "properties": {
+            "axisType": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Categorical'"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "labels": [
+        {
+          "properties": {
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "dataPoint": [
+        {
+          "properties": {
+            "fill": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 3,
+                      "Percent": 0
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "visualContainerObjects": {
+      "visualHeader": [
+        {
+          "properties": {
+            "showCopyVisualImageButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFilterRestatementButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFocusModeButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showPinButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/projects/fabric/template/sandbox/dataops.Report/definition/pages/d064789b4f2768213eb4/visuals/84b26691d849e8e39e88/visual.json
+++ b/projects/fabric/template/sandbox/dataops.Report/definition/pages/d064789b4f2768213eb4/visuals/84b26691d849e8e39e88/visual.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.7.0/schema.json",
+  "name": "84b26691d849e8e39e88",
+  "position": {
+    "x": 632,
+    "y": 64,
+    "z": 2200,
+    "height": 92,
+    "width": 300,
+    "tabOrder": 2200
+  },
+  "visual": {
+    "visualType": "multiRowCard",
+    "query": {
+      "queryState": {
+        "Values": {
+          "projections": [
+            {
+              "field": {
+                "Measure": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "fct_dbt_node_execution"
+                    }
+                  },
+                  "Property": "Failed Nodes"
+                }
+              },
+              "queryRef": "fct_dbt_node_execution.Failed Nodes",
+              "nativeQueryRef": "Failed Nodes"
+            }
+          ]
+        }
+      }
+    },
+    "objects": {
+      "card": [
+        {
+          "properties": {
+            "barColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 2,
+                      "Percent": 0
+                    }
+                  }
+                }
+              }
+            },
+            "barWeight": {
+              "expr": {
+                "Literal": {
+                  "Value": "4L"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "dataLabels": [
+        {
+          "properties": {
+            "fontFamily": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Segoe UI'"
+                }
+              }
+            },
+            "fontSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "11L"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "categoryLabels": [
+        {
+          "properties": {
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 1,
+                      "Percent": 0.4
+                    }
+                  }
+                }
+              }
+            },
+            "fontSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "11L"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "visualContainerObjects": {
+      "visualHeader": [
+        {
+          "properties": {
+            "showCopyVisualImageButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFilterRestatementButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFocusModeButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showPinButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showPersonalizeVisualButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/projects/fabric/template/sandbox/dataops.Report/definition/pages/d064789b4f2768213eb4/visuals/855366ef427e92afa44c/visual.json
+++ b/projects/fabric/template/sandbox/dataops.Report/definition/pages/d064789b4f2768213eb4/visuals/855366ef427e92afa44c/visual.json
@@ -1,0 +1,175 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.7.0/schema.json",
+  "name": "855366ef427e92afa44c",
+  "position": {
+    "x": 956,
+    "y": 430,
+    "z": 4200,
+    "height": 274,
+    "width": 308,
+    "tabOrder": 4200
+  },
+  "visual": {
+    "visualType": "clusteredBarChart",
+    "query": {
+      "queryState": {
+        "Category": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "dim_dbt_test_type"
+                    }
+                  },
+                  "Property": "test_family"
+                }
+              },
+              "queryRef": "dim_dbt_test_type.test_family",
+              "nativeQueryRef": "test_family",
+              "active": true
+            }
+          ]
+        },
+        "Y": {
+          "projections": [
+            {
+              "field": {
+                "Measure": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "fct_dbt_node_execution"
+                    }
+                  },
+                  "Property": "Total Node Executions"
+                }
+              },
+              "queryRef": "fct_dbt_node_execution.Total Node Executions",
+              "nativeQueryRef": "Total Node Executions"
+            }
+          ]
+        },
+        "Series": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "dim_dbt_status"
+                    }
+                  },
+                  "Property": "status_group"
+                }
+              },
+              "queryRef": "dim_dbt_status.status_group",
+              "nativeQueryRef": "status_group"
+            }
+          ]
+        }
+      },
+      "sortDefinition": {
+        "sort": [
+          {
+            "field": {
+              "Measure": {
+                "Expression": {
+                  "SourceRef": {
+                    "Entity": "fct_dbt_node_execution"
+                  }
+                },
+                "Property": "Total Node Executions"
+              }
+            },
+            "direction": "Descending"
+          }
+        ],
+        "isDefaultSort": true
+      }
+    },
+    "objects": {
+      "categoryAxis": [
+        {
+          "properties": {
+            "axisType": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Categorical'"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "labels": [
+        {
+          "properties": {
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "dataPoint": [
+        {
+          "properties": {
+            "fill": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 3,
+                      "Percent": 0
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "visualContainerObjects": {
+      "visualHeader": [
+        {
+          "properties": {
+            "showCopyVisualImageButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFilterRestatementButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFocusModeButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showPinButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/projects/fabric/template/sandbox/dataops.Report/definition/pages/d064789b4f2768213eb4/visuals/996c7e56d7977a5a100b/visual.json
+++ b/projects/fabric/template/sandbox/dataops.Report/definition/pages/d064789b4f2768213eb4/visuals/996c7e56d7977a5a100b/visual.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.7.0/schema.json",
+  "name": "996c7e56d7977a5a100b",
+  "position": {
+    "x": 324,
+    "y": 64,
+    "z": 2100,
+    "height": 92,
+    "width": 300,
+    "tabOrder": 2100
+  },
+  "visual": {
+    "visualType": "multiRowCard",
+    "query": {
+      "queryState": {
+        "Values": {
+          "projections": [
+            {
+              "field": {
+                "Measure": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "fct_dbt_node_execution"
+                    }
+                  },
+                  "Property": "Success Rate"
+                }
+              },
+              "queryRef": "fct_dbt_node_execution.Success Rate",
+              "nativeQueryRef": "Success Rate"
+            }
+          ]
+        }
+      }
+    },
+    "objects": {
+      "card": [
+        {
+          "properties": {
+            "barColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 2,
+                      "Percent": 0
+                    }
+                  }
+                }
+              }
+            },
+            "barWeight": {
+              "expr": {
+                "Literal": {
+                  "Value": "4L"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "dataLabels": [
+        {
+          "properties": {
+            "fontFamily": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Segoe UI'"
+                }
+              }
+            },
+            "fontSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "11L"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "categoryLabels": [
+        {
+          "properties": {
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 1,
+                      "Percent": 0.4
+                    }
+                  }
+                }
+              }
+            },
+            "fontSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "11L"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "visualContainerObjects": {
+      "visualHeader": [
+        {
+          "properties": {
+            "showCopyVisualImageButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFilterRestatementButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFocusModeButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showPinButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showPersonalizeVisualButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/projects/fabric/template/sandbox/dataops.Report/definition/pages/d064789b4f2768213eb4/visuals/c3e874e47814637ba0e1/visual.json
+++ b/projects/fabric/template/sandbox/dataops.Report/definition/pages/d064789b4f2768213eb4/visuals/c3e874e47814637ba0e1/visual.json
@@ -1,0 +1,157 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.7.0/schema.json",
+  "name": "c3e874e47814637ba0e1",
+  "position": {
+    "x": 648,
+    "y": 430,
+    "z": 4100,
+    "height": 274,
+    "width": 300,
+    "tabOrder": 4100
+  },
+  "visual": {
+    "visualType": "clusteredColumnChart",
+    "query": {
+      "queryState": {
+        "Category": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "dim_dbt_resource_type"
+                    }
+                  },
+                  "Property": "resource_type"
+                }
+              },
+              "queryRef": "dim_dbt_resource_type.resource_type",
+              "nativeQueryRef": "resource_type",
+              "active": true
+            }
+          ]
+        },
+        "Y": {
+          "projections": [
+            {
+              "field": {
+                "Measure": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "fct_dbt_node_execution"
+                    }
+                  },
+                  "Property": "Total Node Executions"
+                }
+              },
+              "queryRef": "fct_dbt_node_execution.Total Node Executions",
+              "nativeQueryRef": "Total Node Executions"
+            }
+          ]
+        }
+      },
+      "sortDefinition": {
+        "sort": [
+          {
+            "field": {
+              "Measure": {
+                "Expression": {
+                  "SourceRef": {
+                    "Entity": "fct_dbt_node_execution"
+                  }
+                },
+                "Property": "Total Node Executions"
+              }
+            },
+            "direction": "Descending"
+          }
+        ],
+        "isDefaultSort": true
+      }
+    },
+    "objects": {
+      "categoryAxis": [
+        {
+          "properties": {
+            "axisType": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Categorical'"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "labels": [
+        {
+          "properties": {
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "dataPoint": [
+        {
+          "properties": {
+            "fill": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 3,
+                      "Percent": 0
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "visualContainerObjects": {
+      "visualHeader": [
+        {
+          "properties": {
+            "showCopyVisualImageButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFilterRestatementButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFocusModeButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showPinButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/projects/fabric/template/sandbox/dataops.Report/definition/pages/d064789b4f2768213eb4/visuals/d996114f69644475fdeb/visual.json
+++ b/projects/fabric/template/sandbox/dataops.Report/definition/pages/d064789b4f2768213eb4/visuals/d996114f69644475fdeb/visual.json
@@ -1,0 +1,157 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.7.0/schema.json",
+  "name": "d996114f69644475fdeb",
+  "position": {
+    "x": 648,
+    "y": 168,
+    "z": 3100,
+    "height": 250,
+    "width": 616,
+    "tabOrder": 3100
+  },
+  "visual": {
+    "visualType": "clusteredBarChart",
+    "query": {
+      "queryState": {
+        "Category": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "dim_dbt_project"
+                    }
+                  },
+                  "Property": "project"
+                }
+              },
+              "queryRef": "dim_dbt_project.project",
+              "nativeQueryRef": "project",
+              "active": true
+            }
+          ]
+        },
+        "Y": {
+          "projections": [
+            {
+              "field": {
+                "Measure": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "fct_dbt_node_execution"
+                    }
+                  },
+                  "Property": "Success Rate"
+                }
+              },
+              "queryRef": "fct_dbt_node_execution.Success Rate",
+              "nativeQueryRef": "Success Rate"
+            }
+          ]
+        }
+      },
+      "sortDefinition": {
+        "sort": [
+          {
+            "field": {
+              "Measure": {
+                "Expression": {
+                  "SourceRef": {
+                    "Entity": "fct_dbt_node_execution"
+                  }
+                },
+                "Property": "Success Rate"
+              }
+            },
+            "direction": "Descending"
+          }
+        ],
+        "isDefaultSort": true
+      }
+    },
+    "objects": {
+      "categoryAxis": [
+        {
+          "properties": {
+            "axisType": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Categorical'"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "labels": [
+        {
+          "properties": {
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "dataPoint": [
+        {
+          "properties": {
+            "fill": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 3,
+                      "Percent": 0
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "visualContainerObjects": {
+      "visualHeader": [
+        {
+          "properties": {
+            "showCopyVisualImageButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFilterRestatementButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showFocusModeButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "showPinButton": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/projects/fabric/template/sandbox/dataops.Report/definition/pages/pages.json
+++ b/projects/fabric/template/sandbox/dataops.Report/definition/pages/pages.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/pagesMetadata/1.0.0/schema.json",
+  "pageOrder": [
+    "d064789b4f2768213eb4",
+    "85e27d67efd2bef4072d"
+  ],
+  "activePageName": "d064789b4f2768213eb4"
+}

--- a/projects/fabric/template/sandbox/dataops.Report/definition/report.json
+++ b/projects/fabric/template/sandbox/dataops.Report/definition/report.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/report/3.2.0/schema.json",
+  "themeCollection": {
+    "baseTheme": {
+      "name": "CY26SU02",
+      "reportVersionAtImport": {
+        "visual": "2.6.0",
+        "report": "3.1.0",
+        "page": "2.3.0"
+      },
+      "type": "SharedResources"
+    }
+  },
+  "objects": {
+    "section": [
+      {
+        "properties": {
+          "verticalAlignment": {
+            "expr": {
+              "Literal": {
+                "Value": "'Top'"
+              }
+            }
+          }
+        }
+      }
+    ],
+    "outspacePane": [
+      {
+        "properties": {
+          "expanded": {
+            "expr": {
+              "Literal": {
+                "Value": "false"
+              }
+            }
+          }
+        }
+      }
+    ]
+  },
+  "reportSource": "QuickCreate",
+  "resourcePackages": [
+    {
+      "name": "SharedResources",
+      "type": "SharedResources",
+      "items": [
+        {
+          "name": "CY26SU02",
+          "path": "BaseThemes/CY26SU02.json",
+          "type": "BaseTheme"
+        }
+      ]
+    }
+  ],
+  "settings": {
+    "useStylableVisualContainerHeader": true,
+    "exportDataMode": "AllowSummarized",
+    "defaultDrillFilterOtherVisuals": true,
+    "allowChangeFilterTypes": true,
+    "allowInlineExploration": true,
+    "useEnhancedTooltips": true,
+    "useDefaultAggregateDisplayName": true
+  }
+}

--- a/projects/fabric/template/sandbox/dataops.Report/definition/version.json
+++ b/projects/fabric/template/sandbox/dataops.Report/definition/version.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/versionMetadata/1.0.0/schema.json",
+  "version": "2.0.0"
+}

--- a/projects/fabric/template/sandbox/dataops.SemanticModel/.platform
+++ b/projects/fabric/template/sandbox/dataops.SemanticModel/.platform
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/gitIntegration/platformProperties/2.0.0/schema.json",
+  "metadata": {
+    "type": "SemanticModel",
+    "displayName": "dataops"
+  },
+  "config": {
+    "version": "2.0",
+    "logicalId": "33ffb01b-70ea-445d-9670-1ed0635a83f1"
+  }
+}

--- a/projects/fabric/template/sandbox/dataops.SemanticModel/definition.pbism
+++ b/projects/fabric/template/sandbox/dataops.SemanticModel/definition.pbism
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/semanticModel/definitionProperties/1.0.0/schema.json",
+  "version": "4.2",
+  "settings": {}
+}

--- a/projects/fabric/template/sandbox/dataops.SemanticModel/definition/database.tmdl
+++ b/projects/fabric/template/sandbox/dataops.SemanticModel/definition/database.tmdl
@@ -1,0 +1,3 @@
+database
+	compatibilityLevel: 1604
+

--- a/projects/fabric/template/sandbox/dataops.SemanticModel/definition/expressions.tmdl
+++ b/projects/fabric/template/sandbox/dataops.SemanticModel/definition/expressions.tmdl
@@ -1,0 +1,10 @@
+expression 'DirectLake - dbt_dataops_dwh' =
+		let
+		    Source = AzureStorage.DataLake("https://onelake.dfs.fabric.microsoft.com/3ea60ae5-e979-4d31-a317-66491ab497fb/091ca1a7-9243-4453-8199-8d0663598107", [HierarchicalNavigation=true])
+		in
+		    Source
+	lineageTag: 8af05ba1-c972-4bac-b5f2-088b4b6404b9
+
+	annotation PBI_IncludeFutureArtifacts = False
+
+	annotation PBI_RemovedChildren = []

--- a/projects/fabric/template/sandbox/dataops.SemanticModel/definition/model.tmdl
+++ b/projects/fabric/template/sandbox/dataops.SemanticModel/definition/model.tmdl
@@ -1,0 +1,29 @@
+model Model
+	culture: en-US
+	defaultPowerBIDataSourceVersion: powerBI_V3
+	sourceQueryCulture: en-US
+	dataAccessOptions
+		legacyRedirects
+		returnErrorValuesAsNull
+
+annotation PBI_QueryOrder = ["DirectLake - dbt_dataops_dwh"]
+
+annotation __PBI_TimeIntelligenceEnabled = 1
+
+annotation PBI_ProTooling = ["DirectLakeOnOneLakeInWeb","MCP-PBIModeling"]
+
+ref table dim_date
+ref table dim_dbt_project
+ref table dim_dbt_resource_type
+ref table dim_dbt_status
+ref table dim_dbt_materialization
+ref table dim_dbt_test_type
+ref table dim_dbt_node
+ref table fct_dbt_node_execution
+ref table fct_dbt_invocation
+ref table dim_delta_table
+ref table dim_delta_table_operation_type
+ref table dim_delta_table_health_status
+ref table fct_delta_commit
+ref table fct_delta_storage
+ref table fct_delta_health

--- a/projects/fabric/template/sandbox/dataops.SemanticModel/definition/relationships.tmdl
+++ b/projects/fabric/template/sandbox/dataops.SemanticModel/definition/relationships.tmdl
@@ -1,0 +1,77 @@
+relationship fct_dbt_node_execution_node_key_dim_dbt_node_node_key
+	fromColumn: fct_dbt_node_execution.node_key
+	toColumn: dim_dbt_node.node_key
+
+relationship fct_dbt_node_execution_project_key_dim_dbt_project_project_key
+	fromColumn: fct_dbt_node_execution.project_key
+	toColumn: dim_dbt_project.project_key
+
+relationship fct_dbt_node_execution_resource_type_key_dim_dbt_resource_type_resource_type_key
+	fromColumn: fct_dbt_node_execution.resource_type_key
+	toColumn: dim_dbt_resource_type.resource_type_key
+
+relationship fct_dbt_node_execution_status_key_dim_dbt_status_status_key
+	fromColumn: fct_dbt_node_execution.status_key
+	toColumn: dim_dbt_status.status_key
+
+relationship fct_dbt_node_execution_materialization_key_dim_dbt_materialization_materialization_key
+	fromColumn: fct_dbt_node_execution.materialization_key
+	toColumn: dim_dbt_materialization.materialization_key
+
+relationship fct_dbt_node_execution_test_type_key_dim_dbt_test_type_test_type_key
+	fromColumn: fct_dbt_node_execution.test_type_key
+	toColumn: dim_dbt_test_type.test_type_key
+
+relationship fct_dbt_node_execution_date_key_dim_date_date_key
+	fromColumn: fct_dbt_node_execution.date_key
+	toColumn: dim_date.date_key
+
+relationship fct_dbt_invocation_project_key_dim_dbt_project_project_key
+	fromColumn: fct_dbt_invocation.project_key
+	toColumn: dim_dbt_project.project_key
+
+relationship fct_dbt_invocation_date_key_dim_date_date_key
+	fromColumn: fct_dbt_invocation.date_key
+	toColumn: dim_date.date_key
+
+relationship fct_delta_commit_table_key_dim_delta_table___pk
+	fromColumn: fct_delta_commit.table_key
+	toColumn: dim_delta_table.__pk
+
+relationship fct_delta_commit_operation_type_key_dim_delta_table_operation_type_operation_type_key
+	fromColumn: fct_delta_commit.operation_type_key
+	toColumn: dim_delta_table_operation_type.operation_type_key
+
+relationship fct_delta_commit_date_key_dim_date_date_key
+	fromColumn: fct_delta_commit.date_key
+	toColumn: dim_date.date_key
+
+relationship fct_delta_storage_table_key_dim_delta_table___pk
+	fromColumn: fct_delta_storage.table_key
+	toColumn: dim_delta_table.__pk
+
+relationship fct_delta_storage_date_key_dim_date_date_key
+	fromColumn: fct_delta_storage.date_key
+	toColumn: dim_date.date_key
+
+relationship fct_delta_health_table_key_dim_delta_table___pk
+	fromColumn: fct_delta_health.table_key
+	toColumn: dim_delta_table.__pk
+
+relationship fct_delta_health_date_key_dim_date_date_key
+	fromColumn: fct_delta_health.date_key
+	toColumn: dim_date.date_key
+
+relationship fct_delta_health_overall_status_key_dim_delta_table_health_status_health_status_key
+	fromColumn: fct_delta_health.overall_status_key
+	toColumn: dim_delta_table_health_status.health_status_key
+
+relationship fct_delta_health_freshness_status_key_dim_delta_table_health_status_health_status_key
+	fromColumn: fct_delta_health.freshness_status_key
+	toColumn: dim_delta_table_health_status.health_status_key
+	isActive: false
+
+relationship fct_delta_health_completeness_status_key_dim_delta_table_health_status_health_status_key
+	fromColumn: fct_delta_health.completeness_status_key
+	toColumn: dim_delta_table_health_status.health_status_key
+	isActive: false

--- a/projects/fabric/template/sandbox/dataops.SemanticModel/definition/tables/dim_date.tmdl
+++ b/projects/fabric/template/sandbox/dataops.SemanticModel/definition/tables/dim_date.tmdl
@@ -1,0 +1,115 @@
+table dim_date
+	lineageTag: 5c75a537-f45d-4c85-849b-ba1631799f52
+	sourceLineageTag: [dbo].[dim_date]
+
+	column date_key
+		dataType: string
+		lineageTag: 9112838c-9164-4562-ad5c-90e7b07fefb7
+		sourceLineageTag: date_key
+		summarizeBy: none
+		sourceColumn: date_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column full_date
+		dataType: dateTime
+		formatString: General Date
+		lineageTag: c8e436ce-6361-4b7c-8cb9-1e1697f8636a
+		sourceLineageTag: full_date
+		summarizeBy: none
+		sourceColumn: full_date
+
+		annotation SummarizationSetBy = Automatic
+
+	column year
+		dataType: int64
+		formatString: 0
+		lineageTag: 1253ce87-ac8a-4032-97e3-6de9f0ff432b
+		sourceLineageTag: year
+		summarizeBy: none
+		sourceColumn: year
+
+		annotation SummarizationSetBy = Automatic
+
+	column quarter
+		dataType: int64
+		formatString: 0
+		lineageTag: adaca847-1b35-40fe-b2db-e7fdb85e2fba
+		sourceLineageTag: quarter
+		summarizeBy: none
+		sourceColumn: quarter
+
+		annotation SummarizationSetBy = Automatic
+
+	column month
+		dataType: int64
+		formatString: 0
+		lineageTag: 8740d2a9-6bb9-4936-bbc9-b9e1fa10deea
+		sourceLineageTag: month
+		summarizeBy: none
+		sourceColumn: month
+
+		annotation SummarizationSetBy = Automatic
+
+	column month_name
+		dataType: string
+		lineageTag: bacb0553-782e-47c7-9d38-0f4456475046
+		sourceLineageTag: month_name
+		summarizeBy: none
+		sourceColumn: month_name
+
+		annotation SummarizationSetBy = Automatic
+
+	column day_of_month
+		dataType: int64
+		formatString: 0
+		lineageTag: 82cbe8ef-6bda-4ac5-b04a-8d5accde9735
+		sourceLineageTag: day_of_month
+		summarizeBy: none
+		sourceColumn: day_of_month
+
+		annotation SummarizationSetBy = Automatic
+
+	column day_of_week
+		dataType: int64
+		formatString: 0
+		lineageTag: f07ea1c6-625b-41c3-9e0b-77271b2a4a19
+		sourceLineageTag: day_of_week
+		summarizeBy: none
+		sourceColumn: day_of_week
+
+		annotation SummarizationSetBy = Automatic
+
+	column day_name
+		dataType: string
+		lineageTag: ab95ddeb-de77-4d83-a867-e71e83e381f2
+		sourceLineageTag: day_name
+		summarizeBy: none
+		sourceColumn: day_name
+
+		annotation SummarizationSetBy = Automatic
+
+	column week_of_year
+		dataType: int64
+		formatString: 0
+		lineageTag: 2179f43c-3e40-4b25-9060-9786b72258f7
+		sourceLineageTag: week_of_year
+		summarizeBy: none
+		sourceColumn: week_of_year
+
+		annotation SummarizationSetBy = Automatic
+
+	column is_weekend
+		dataType: boolean
+		lineageTag: b0b3afae-7bcf-41c0-aeb4-32b176b2fa34
+		sourceLineageTag: is_weekend
+		summarizeBy: none
+		sourceColumn: is_weekend
+
+		annotation SummarizationSetBy = Automatic
+
+	partition dim_date = entity
+		mode: directLake
+		source
+			entityName: dim_date
+			expressionSource: 'DirectLake - dbt_dataops_dwh'

--- a/projects/fabric/template/sandbox/dataops.SemanticModel/definition/tables/dim_dbt_materialization.tmdl
+++ b/projects/fabric/template/sandbox/dataops.SemanticModel/definition/tables/dim_dbt_materialization.tmdl
@@ -1,0 +1,63 @@
+table dim_dbt_materialization
+	lineageTag: 722d833b-c7b2-4952-8bc5-c2331d1022b0
+	sourceLineageTag: [dbo].[dim_dbt_materialization]
+
+	column materialization_key
+		dataType: string
+		lineageTag: ca6733f8-2b9c-4f2f-b40f-76a276dd0c00
+		sourceLineageTag: materialization_key
+		summarizeBy: none
+		sourceColumn: materialization_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column materialized
+		dataType: string
+		lineageTag: 6535fc82-7c2b-4306-b02b-5590bc57fd9e
+		sourceLineageTag: materialized
+		summarizeBy: none
+		sourceColumn: materialized
+
+		annotation SummarizationSetBy = Automatic
+
+	column storage_class
+		dataType: string
+		lineageTag: 472b5662-1085-4655-87dd-38e803f30ce4
+		sourceLineageTag: storage_class
+		summarizeBy: none
+		sourceColumn: storage_class
+
+		annotation SummarizationSetBy = Automatic
+
+	column is_persisted
+		dataType: boolean
+		lineageTag: 3cdc57c0-7d69-425a-b6e2-1f4a3877b5d1
+		sourceLineageTag: is_persisted
+		summarizeBy: none
+		sourceColumn: is_persisted
+
+		annotation SummarizationSetBy = Automatic
+
+	column is_rebuilt_each_run
+		dataType: boolean
+		lineageTag: eae80d2d-467c-4a83-bf1d-d483045e2d94
+		sourceLineageTag: is_rebuilt_each_run
+		summarizeBy: none
+		sourceColumn: is_rebuilt_each_run
+
+		annotation SummarizationSetBy = Automatic
+
+	column description
+		dataType: string
+		lineageTag: f41105ab-c70c-454e-a5c0-485a3700b2fa
+		sourceLineageTag: description
+		summarizeBy: none
+		sourceColumn: description
+
+		annotation SummarizationSetBy = Automatic
+
+	partition dim_dbt_materialization = entity
+		mode: directLake
+		source
+			entityName: dim_dbt_materialization
+			expressionSource: 'DirectLake - dbt_dataops_dwh'

--- a/projects/fabric/template/sandbox/dataops.SemanticModel/definition/tables/dim_dbt_node.tmdl
+++ b/projects/fabric/template/sandbox/dataops.SemanticModel/definition/tables/dim_dbt_node.tmdl
@@ -1,0 +1,153 @@
+table dim_dbt_node
+	lineageTag: b8e140cd-7afe-4d97-9615-de16d52fb022
+	sourceLineageTag: [dbo].[dim_dbt_node]
+
+	column node_key
+		dataType: string
+		lineageTag: 8e869b0b-7ff5-4508-bfa3-aa315dea3297
+		sourceLineageTag: node_key
+		summarizeBy: none
+		sourceColumn: node_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column unique_id
+		dataType: string
+		lineageTag: 7d20412a-ad3f-4a3a-869e-ada587cfe3f1
+		sourceLineageTag: unique_id
+		summarizeBy: none
+		sourceColumn: unique_id
+
+		annotation SummarizationSetBy = Automatic
+
+	column project
+		dataType: string
+		lineageTag: 178e2a48-5d07-45e1-bbd7-c4da5341c300
+		sourceLineageTag: project
+		summarizeBy: none
+		sourceColumn: project
+
+		annotation SummarizationSetBy = Automatic
+
+	column resource_type
+		dataType: string
+		lineageTag: c11d019e-c017-4135-ba34-ad94f192ed78
+		sourceLineageTag: resource_type
+		summarizeBy: none
+		sourceColumn: resource_type
+
+		annotation SummarizationSetBy = Automatic
+
+	column package_name
+		dataType: string
+		lineageTag: 2b75494b-4cbe-41b4-9e24-0f0e791f9799
+		sourceLineageTag: package_name
+		summarizeBy: none
+		sourceColumn: package_name
+
+		annotation SummarizationSetBy = Automatic
+
+	column node_name
+		dataType: string
+		lineageTag: 6d345f66-9c7a-4871-a0bd-338a1e8a4273
+		sourceLineageTag: node_name
+		summarizeBy: none
+		sourceColumn: node_name
+
+		annotation SummarizationSetBy = Automatic
+
+	column alias
+		dataType: string
+		lineageTag: f5d5624a-b918-4a40-b510-42f3030fa10e
+		sourceLineageTag: alias
+		summarizeBy: none
+		sourceColumn: alias
+
+		annotation SummarizationSetBy = Automatic
+
+	column database_name
+		dataType: string
+		lineageTag: c7c1787f-2203-4fc6-a03d-5aa0823b1cc0
+		sourceLineageTag: database_name
+		summarizeBy: none
+		sourceColumn: database_name
+
+		annotation SummarizationSetBy = Automatic
+
+	column schema_name
+		dataType: string
+		lineageTag: 86bd5c9c-9459-4465-a2e5-32ae1e852275
+		sourceLineageTag: schema_name
+		summarizeBy: none
+		sourceColumn: schema_name
+
+		annotation SummarizationSetBy = Automatic
+
+	column relation_name
+		dataType: string
+		lineageTag: 329a530f-d2da-47ae-a4be-685e82f9e832
+		sourceLineageTag: relation_name
+		summarizeBy: none
+		sourceColumn: relation_name
+
+		annotation SummarizationSetBy = Automatic
+
+	column original_file_path
+		dataType: string
+		lineageTag: 7cc0a24d-2e4d-4616-9368-66bfbde93d87
+		sourceLineageTag: original_file_path
+		summarizeBy: none
+		sourceColumn: original_file_path
+
+		annotation SummarizationSetBy = Automatic
+
+	column materialized
+		dataType: string
+		lineageTag: f508f9c4-316f-46a8-945c-01c26b8ae747
+		sourceLineageTag: materialized
+		summarizeBy: none
+		sourceColumn: materialized
+
+		annotation SummarizationSetBy = Automatic
+
+	column node_layer
+		dataType: string
+		lineageTag: 97baaf5a-b193-4bf9-b1eb-f5e082d0b7a1
+		sourceLineageTag: node_layer
+		summarizeBy: none
+		sourceColumn: node_layer
+
+		annotation SummarizationSetBy = Automatic
+
+	column test_type
+		dataType: string
+		lineageTag: 3cc8ae16-4d63-4127-b015-f7e3f4fc7153
+		sourceLineageTag: test_type
+		summarizeBy: none
+		sourceColumn: test_type
+
+		annotation SummarizationSetBy = Automatic
+
+	column tested_column
+		dataType: string
+		lineageTag: cf73a2a6-b7f3-4644-9e76-77fa574dd863
+		sourceLineageTag: tested_column
+		summarizeBy: none
+		sourceColumn: tested_column
+
+		annotation SummarizationSetBy = Automatic
+
+	column is_test
+		dataType: boolean
+		lineageTag: 4db849d2-0fa1-4a8c-93be-4ceeb5174196
+		sourceLineageTag: is_test
+		summarizeBy: none
+		sourceColumn: is_test
+
+		annotation SummarizationSetBy = Automatic
+
+	partition dim_dbt_node = entity
+		mode: directLake
+		source
+			entityName: dim_dbt_node
+			expressionSource: 'DirectLake - dbt_dataops_dwh'

--- a/projects/fabric/template/sandbox/dataops.SemanticModel/definition/tables/dim_dbt_project.tmdl
+++ b/projects/fabric/template/sandbox/dataops.SemanticModel/definition/tables/dim_dbt_project.tmdl
@@ -1,0 +1,54 @@
+table dim_dbt_project
+	lineageTag: fbae8bf1-0f11-44c5-b86a-d53729a33a8f
+	sourceLineageTag: [dbo].[dim_dbt_project]
+
+	column project_key
+		dataType: string
+		lineageTag: ee8ca441-a992-4570-b619-6ec6e4046512
+		sourceLineageTag: project_key
+		summarizeBy: none
+		sourceColumn: project_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column project
+		dataType: string
+		lineageTag: 4fbe74dc-0f16-4d0c-bf34-6333853b4e2c
+		sourceLineageTag: project
+		summarizeBy: none
+		sourceColumn: project
+
+		annotation SummarizationSetBy = Automatic
+
+	column project_domain
+		dataType: string
+		lineageTag: a7161a09-d59f-413c-a749-9b91cf506447
+		sourceLineageTag: project_domain
+		summarizeBy: none
+		sourceColumn: project_domain
+
+		annotation SummarizationSetBy = Automatic
+
+	column project_description
+		dataType: string
+		lineageTag: 2e65b5d3-68e7-49fe-8fdc-680297473f8f
+		sourceLineageTag: project_description
+		summarizeBy: none
+		sourceColumn: project_description
+
+		annotation SummarizationSetBy = Automatic
+
+	column is_demo
+		dataType: boolean
+		lineageTag: 9acbf102-cf13-470b-9d69-465ceb962813
+		sourceLineageTag: is_demo
+		summarizeBy: none
+		sourceColumn: is_demo
+
+		annotation SummarizationSetBy = Automatic
+
+	partition dim_dbt_project = entity
+		mode: directLake
+		source
+			entityName: dim_dbt_project
+			expressionSource: 'DirectLake - dbt_dataops_dwh'

--- a/projects/fabric/template/sandbox/dataops.SemanticModel/definition/tables/dim_dbt_resource_type.tmdl
+++ b/projects/fabric/template/sandbox/dataops.SemanticModel/definition/tables/dim_dbt_resource_type.tmdl
@@ -1,0 +1,72 @@
+table dim_dbt_resource_type
+	lineageTag: 7e6edc6b-98b4-4261-a872-1df234c1fd33
+	sourceLineageTag: [dbo].[dim_dbt_resource_type]
+
+	column resource_type_key
+		dataType: string
+		lineageTag: 554e7b8a-3cca-4b99-aa69-aa8dca7e6a99
+		sourceLineageTag: resource_type_key
+		summarizeBy: none
+		sourceColumn: resource_type_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column resource_type
+		dataType: string
+		lineageTag: cd697009-3b15-446f-a266-ed638d72b2a5
+		sourceLineageTag: resource_type
+		summarizeBy: none
+		sourceColumn: resource_type
+
+		annotation SummarizationSetBy = Automatic
+
+	column resource_category
+		dataType: string
+		lineageTag: af1eda9a-a446-4891-90ee-689055363c8a
+		sourceLineageTag: resource_category
+		summarizeBy: none
+		sourceColumn: resource_category
+
+		annotation SummarizationSetBy = Automatic
+
+	column is_executable
+		dataType: boolean
+		lineageTag: 33ecac16-cfc3-4615-aea9-ca4b72a8bba0
+		sourceLineageTag: is_executable
+		summarizeBy: none
+		sourceColumn: is_executable
+
+		annotation SummarizationSetBy = Automatic
+
+	column is_test
+		dataType: boolean
+		lineageTag: cb71489d-883a-44fb-8dcc-33bb39ba9fa9
+		sourceLineageTag: is_test
+		summarizeBy: none
+		sourceColumn: is_test
+
+		annotation SummarizationSetBy = Automatic
+
+	column is_data
+		dataType: boolean
+		lineageTag: 28e456d2-6e3b-4e79-8134-2664d7930973
+		sourceLineageTag: is_data
+		summarizeBy: none
+		sourceColumn: is_data
+
+		annotation SummarizationSetBy = Automatic
+
+	column description
+		dataType: string
+		lineageTag: abe0f7a1-7995-4fef-86c5-786f26609f58
+		sourceLineageTag: description
+		summarizeBy: none
+		sourceColumn: description
+
+		annotation SummarizationSetBy = Automatic
+
+	partition dim_dbt_resource_type = entity
+		mode: directLake
+		source
+			entityName: dim_dbt_resource_type
+			expressionSource: 'DirectLake - dbt_dataops_dwh'

--- a/projects/fabric/template/sandbox/dataops.SemanticModel/definition/tables/dim_dbt_status.tmdl
+++ b/projects/fabric/template/sandbox/dataops.SemanticModel/definition/tables/dim_dbt_status.tmdl
@@ -1,0 +1,73 @@
+table dim_dbt_status
+	lineageTag: 95cb0e8b-3f78-4af2-888d-b0d45f475786
+	sourceLineageTag: [dbo].[dim_dbt_status]
+
+	column status_key
+		dataType: string
+		lineageTag: 16bd8675-15e0-446e-ae97-0bda101aeea7
+		sourceLineageTag: status_key
+		summarizeBy: none
+		sourceColumn: status_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column status
+		dataType: string
+		lineageTag: 109d7336-9b4a-48d3-af04-f8229a65ea0e
+		sourceLineageTag: status
+		summarizeBy: none
+		sourceColumn: status
+
+		annotation SummarizationSetBy = Automatic
+
+	column status_group
+		dataType: string
+		lineageTag: d90b63cb-5d15-42f1-a0f6-628238af3f50
+		sourceLineageTag: status_group
+		summarizeBy: none
+		sourceColumn: status_group
+
+		annotation SummarizationSetBy = Automatic
+
+	column is_passing
+		dataType: boolean
+		lineageTag: 5787e91f-5eeb-4cdd-85ff-397c88ad9e4d
+		sourceLineageTag: is_passing
+		summarizeBy: none
+		sourceColumn: is_passing
+
+		annotation SummarizationSetBy = Automatic
+
+	column is_failure
+		dataType: boolean
+		lineageTag: 68b002d6-5189-4f4b-b60a-d570633ba631
+		sourceLineageTag: is_failure
+		summarizeBy: none
+		sourceColumn: is_failure
+
+		annotation SummarizationSetBy = Automatic
+
+	column severity_rank
+		dataType: int64
+		formatString: 0
+		lineageTag: fd15e076-fe87-4170-9834-13769ffeec7b
+		sourceLineageTag: severity_rank
+		summarizeBy: none
+		sourceColumn: severity_rank
+
+		annotation SummarizationSetBy = Automatic
+
+	column description
+		dataType: string
+		lineageTag: bba09fc7-c89c-43d5-a4d9-49efd7236bae
+		sourceLineageTag: description
+		summarizeBy: none
+		sourceColumn: description
+
+		annotation SummarizationSetBy = Automatic
+
+	partition dim_dbt_status = entity
+		mode: directLake
+		source
+			entityName: dim_dbt_status
+			expressionSource: 'DirectLake - dbt_dataops_dwh'

--- a/projects/fabric/template/sandbox/dataops.SemanticModel/definition/tables/dim_dbt_test_type.tmdl
+++ b/projects/fabric/template/sandbox/dataops.SemanticModel/definition/tables/dim_dbt_test_type.tmdl
@@ -1,0 +1,54 @@
+table dim_dbt_test_type
+	lineageTag: af64f54d-7379-4b72-a3fa-b62215c1ffd8
+	sourceLineageTag: [dbo].[dim_dbt_test_type]
+
+	column test_type_key
+		dataType: string
+		lineageTag: f3bb895a-2c94-4a9f-8314-62617b240ded
+		sourceLineageTag: test_type_key
+		summarizeBy: none
+		sourceColumn: test_type_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column test_type
+		dataType: string
+		lineageTag: fe09d134-998f-4e6a-b537-e55cd3004a95
+		sourceLineageTag: test_type
+		summarizeBy: none
+		sourceColumn: test_type
+
+		annotation SummarizationSetBy = Automatic
+
+	column test_family
+		dataType: string
+		lineageTag: 3da527cd-520c-4feb-bbbb-69cc0ee8fcc6
+		sourceLineageTag: test_family
+		summarizeBy: none
+		sourceColumn: test_family
+
+		annotation SummarizationSetBy = Automatic
+
+	column package
+		dataType: string
+		lineageTag: 5b74da9c-68a0-4065-a5e3-74d5a108d15f
+		sourceLineageTag: package
+		summarizeBy: none
+		sourceColumn: package
+
+		annotation SummarizationSetBy = Automatic
+
+	column is_generic
+		dataType: boolean
+		lineageTag: 17756434-2ccb-4c74-8b23-be6b0b65a710
+		sourceLineageTag: is_generic
+		summarizeBy: none
+		sourceColumn: is_generic
+
+		annotation SummarizationSetBy = Automatic
+
+	partition dim_dbt_test_type = entity
+		mode: directLake
+		source
+			entityName: dim_dbt_test_type
+			expressionSource: 'DirectLake - dbt_dataops_dwh'

--- a/projects/fabric/template/sandbox/dataops.SemanticModel/definition/tables/dim_delta_table.tmdl
+++ b/projects/fabric/template/sandbox/dataops.SemanticModel/definition/tables/dim_delta_table.tmdl
@@ -1,0 +1,195 @@
+table dim_delta_table
+	lineageTag: d00ebf9e-6f63-440f-aaca-3ebd53174f3e
+	sourceLineageTag: [dbo].[dim_delta_table]
+
+	column __pk
+		dataType: string
+		lineageTag: 49ae0226-dde2-4d44-8114-4916aec79926
+		sourceLineageTag: __pk
+		summarizeBy: none
+		sourceColumn: __pk
+
+		annotation SummarizationSetBy = Automatic
+
+	column table_fqn
+		dataType: string
+		lineageTag: 38d459d7-692f-442f-a4aa-e9a837fa6d2a
+		sourceLineageTag: table_fqn
+		summarizeBy: none
+		sourceColumn: table_fqn
+
+		annotation SummarizationSetBy = Automatic
+
+	column database_name
+		dataType: string
+		lineageTag: 5244be71-553b-424b-b6c8-01ef3c65d35d
+		sourceLineageTag: database_name
+		summarizeBy: none
+		sourceColumn: database_name
+
+		annotation SummarizationSetBy = Automatic
+
+	column table_name
+		dataType: string
+		lineageTag: cee96b28-2c59-48f4-b18a-6734dd3e7a12
+		sourceLineageTag: table_name
+		summarizeBy: none
+		sourceColumn: table_name
+
+		annotation SummarizationSetBy = Automatic
+
+	column table_id
+		dataType: string
+		lineageTag: 35b6b3d8-1753-40e3-a3d6-0da84c0747a1
+		sourceLineageTag: table_id
+		summarizeBy: none
+		sourceColumn: table_id
+
+		annotation SummarizationSetBy = Automatic
+
+	column location
+		dataType: string
+		lineageTag: 482ed05f-5411-40b1-a412-03d134d53b0d
+		sourceLineageTag: location
+		summarizeBy: none
+		sourceColumn: location
+
+		annotation SummarizationSetBy = Automatic
+
+	column format
+		dataType: string
+		lineageTag: 8b68f9a0-fa23-4a4c-9309-0c238fd7a1cb
+		sourceLineageTag: format
+		summarizeBy: none
+		sourceColumn: format
+
+		annotation SummarizationSetBy = Automatic
+
+	column partition_columns
+		dataType: string
+		lineageTag: cc014b0c-725f-4788-bec5-4dad0f10c4f3
+		sourceLineageTag: partition_columns
+		summarizeBy: none
+		sourceColumn: partition_columns
+
+		annotation SummarizationSetBy = Automatic
+
+	column clustering_columns
+		dataType: string
+		lineageTag: 0c4b7627-83f0-4da7-ae3d-64a2c1dedc0e
+		sourceLineageTag: clustering_columns
+		summarizeBy: none
+		sourceColumn: clustering_columns
+
+		annotation SummarizationSetBy = Automatic
+
+	column table_properties
+		dataType: string
+		lineageTag: 77692d8e-2b80-4d77-8e47-48caf4fad7b5
+		sourceLineageTag: table_properties
+		summarizeBy: none
+		sourceColumn: table_properties
+
+		annotation SummarizationSetBy = Automatic
+
+	column min_reader_version
+		dataType: int64
+		formatString: 0
+		lineageTag: 061bf0b6-4cef-448b-a4bf-949622925f6f
+		sourceLineageTag: min_reader_version
+		summarizeBy: none
+		sourceColumn: min_reader_version
+
+		annotation SummarizationSetBy = Automatic
+
+	column min_writer_version
+		dataType: int64
+		formatString: 0
+		lineageTag: ea9d4dee-4093-4834-a571-e4853ff5661a
+		sourceLineageTag: min_writer_version
+		summarizeBy: none
+		sourceColumn: min_writer_version
+
+		annotation SummarizationSetBy = Automatic
+
+	column __scd2_hash
+		dataType: string
+		lineageTag: 2fe89881-6707-45ff-84b6-4bf1e1686c4f
+		sourceLineageTag: __scd2_hash
+		summarizeBy: none
+		sourceColumn: __scd2_hash
+
+		annotation SummarizationSetBy = Automatic
+
+	column __scd1_hash
+		dataType: string
+		lineageTag: 2e2fb1ae-e852-4b11-a01a-6a7de5bdbf4f
+		sourceLineageTag: __scd1_hash
+		summarizeBy: none
+		sourceColumn: __scd1_hash
+
+		annotation SummarizationSetBy = Automatic
+
+	column __merge_effective_date
+		dataType: dateTime
+		formatString: General Date
+		lineageTag: c96b5268-1f04-4ccd-bfe0-b92f86c4c8b1
+		sourceLineageTag: __merge_effective_date
+		summarizeBy: none
+		sourceColumn: __merge_effective_date
+
+		annotation SummarizationSetBy = Automatic
+
+	column row_effective_start
+		dataType: dateTime
+		formatString: General Date
+		lineageTag: ade951e5-d79b-42a9-a981-783f342b52da
+		sourceLineageTag: row_effective_start
+		summarizeBy: none
+		sourceColumn: row_effective_start
+
+		annotation SummarizationSetBy = Automatic
+
+	column row_effective_end
+		dataType: dateTime
+		formatString: General Date
+		lineageTag: fbff6aaa-218e-4f3e-897c-f78b50d55a3f
+		sourceLineageTag: row_effective_end
+		summarizeBy: none
+		sourceColumn: row_effective_end
+
+		annotation SummarizationSetBy = Automatic
+
+	column is_row_effective
+		dataType: boolean
+		lineageTag: 8e57e9d6-8ac9-438b-9b9e-4e41f311c0f7
+		sourceLineageTag: is_row_effective
+		summarizeBy: none
+		sourceColumn: is_row_effective
+
+		annotation SummarizationSetBy = Automatic
+
+	column __scd_id
+		dataType: string
+		lineageTag: fc13f5f2-28a1-47d1-a1a6-dbae4a7f64d9
+		sourceLineageTag: __scd_id
+		summarizeBy: none
+		sourceColumn: __scd_id
+
+		annotation SummarizationSetBy = Automatic
+
+	column __merge_ingest_time
+		dataType: dateTime
+		formatString: General Date
+		lineageTag: 82337f62-3046-44c8-96bb-e283ad1fa94e
+		sourceLineageTag: __merge_ingest_time
+		summarizeBy: none
+		sourceColumn: __merge_ingest_time
+
+		annotation SummarizationSetBy = Automatic
+
+	partition dim_delta_table = entity
+		mode: directLake
+		source
+			entityName: dim_delta_table
+			expressionSource: 'DirectLake - dbt_dataops_dwh'

--- a/projects/fabric/template/sandbox/dataops.SemanticModel/definition/tables/dim_delta_table_health_status.tmdl
+++ b/projects/fabric/template/sandbox/dataops.SemanticModel/definition/tables/dim_delta_table_health_status.tmdl
@@ -1,0 +1,46 @@
+table dim_delta_table_health_status
+	lineageTag: 3dfc947a-a458-4e4b-b085-91b834534ad3
+	sourceLineageTag: [dbo].[dim_delta_table_health_status]
+
+	column health_status_key
+		dataType: string
+		lineageTag: 8ce1418d-0fa6-4f52-87cc-e1110ab2d1ab
+		sourceLineageTag: health_status_key
+		summarizeBy: none
+		sourceColumn: health_status_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column status
+		dataType: string
+		lineageTag: 2d8211c5-9be3-40df-9a8f-181cdad52d44
+		sourceLineageTag: status
+		summarizeBy: none
+		sourceColumn: status
+
+		annotation SummarizationSetBy = Automatic
+
+	column description
+		dataType: string
+		lineageTag: ea728fd8-d37e-4ccc-a134-842f60fa51fc
+		sourceLineageTag: description
+		summarizeBy: none
+		sourceColumn: description
+
+		annotation SummarizationSetBy = Automatic
+
+	column severity_rank
+		dataType: int64
+		formatString: 0
+		lineageTag: c24d4655-1cc3-4fa1-96b3-132e890d30f6
+		sourceLineageTag: severity_rank
+		summarizeBy: none
+		sourceColumn: severity_rank
+
+		annotation SummarizationSetBy = Automatic
+
+	partition dim_delta_table_health_status = entity
+		mode: directLake
+		source
+			entityName: dim_delta_table_health_status
+			expressionSource: 'DirectLake - dbt_dataops_dwh'

--- a/projects/fabric/template/sandbox/dataops.SemanticModel/definition/tables/dim_delta_table_operation_type.tmdl
+++ b/projects/fabric/template/sandbox/dataops.SemanticModel/definition/tables/dim_delta_table_operation_type.tmdl
@@ -1,0 +1,63 @@
+table dim_delta_table_operation_type
+	lineageTag: 39437f88-a974-4d5b-b5ed-ed29d5b5c114
+	sourceLineageTag: [dbo].[dim_delta_table_operation_type]
+
+	column operation_type_key
+		dataType: string
+		lineageTag: 96260aab-13e7-44ed-a4c3-11314e4b4ecd
+		sourceLineageTag: operation_type_key
+		summarizeBy: none
+		sourceColumn: operation_type_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column operation
+		dataType: string
+		lineageTag: 6c55bf7d-19e5-4320-bc25-61af62914a21
+		sourceLineageTag: operation
+		summarizeBy: none
+		sourceColumn: operation
+
+		annotation SummarizationSetBy = Automatic
+
+	column operation_category
+		dataType: string
+		lineageTag: 8d976efe-72a9-4b9a-9070-af607bfaedfa
+		sourceLineageTag: operation_category
+		summarizeBy: none
+		sourceColumn: operation_category
+
+		annotation SummarizationSetBy = Automatic
+
+	column is_data_changing
+		dataType: boolean
+		lineageTag: db0c98f3-bf4a-433f-a116-743d215d5582
+		sourceLineageTag: is_data_changing
+		summarizeBy: none
+		sourceColumn: is_data_changing
+
+		annotation SummarizationSetBy = Automatic
+
+	column is_row_producing
+		dataType: boolean
+		lineageTag: c87369c9-c3bf-40fc-9f22-131e6fc83791
+		sourceLineageTag: is_row_producing
+		summarizeBy: none
+		sourceColumn: is_row_producing
+
+		annotation SummarizationSetBy = Automatic
+
+	column description
+		dataType: string
+		lineageTag: b83a32b5-b937-430f-9daf-42e5585225f7
+		sourceLineageTag: description
+		summarizeBy: none
+		sourceColumn: description
+
+		annotation SummarizationSetBy = Automatic
+
+	partition dim_delta_table_operation_type = entity
+		mode: directLake
+		source
+			entityName: dim_delta_table_operation_type
+			expressionSource: 'DirectLake - dbt_dataops_dwh'

--- a/projects/fabric/template/sandbox/dataops.SemanticModel/definition/tables/fct_dbt_invocation.tmdl
+++ b/projects/fabric/template/sandbox/dataops.SemanticModel/definition/tables/fct_dbt_invocation.tmdl
@@ -1,0 +1,322 @@
+table fct_dbt_invocation
+	lineageTag: f30fb87f-f273-458c-aed2-93681807a067
+	sourceLineageTag: [dbo].[fct_dbt_invocation]
+
+	column invocation_key
+		dataType: string
+		lineageTag: e07a423c-59df-40c5-a722-961d4b96287f
+		sourceLineageTag: invocation_key
+		summarizeBy: none
+		sourceColumn: invocation_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column project_key
+		dataType: string
+		lineageTag: 7076319e-e932-4cbf-93af-89df75660e41
+		sourceLineageTag: project_key
+		summarizeBy: none
+		sourceColumn: project_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column date_key
+		dataType: string
+		lineageTag: 6fc9db11-cec8-4935-87d2-0fca3735c318
+		sourceLineageTag: date_key
+		summarizeBy: none
+		sourceColumn: date_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column invocation_id
+		dataType: string
+		lineageTag: 5f1142d2-9cc3-498a-b0de-b0a55599bdee
+		sourceLineageTag: invocation_id
+		summarizeBy: none
+		sourceColumn: invocation_id
+
+		annotation SummarizationSetBy = Automatic
+
+	column command
+		dataType: string
+		lineageTag: e6228727-614c-4072-bdf9-4de2a2438779
+		sourceLineageTag: command
+		summarizeBy: none
+		sourceColumn: command
+
+		annotation SummarizationSetBy = Automatic
+
+	column dbt_version
+		dataType: string
+		lineageTag: f8cc6152-125a-4af6-85ba-c5a292c0d91c
+		sourceLineageTag: dbt_version
+		summarizeBy: none
+		sourceColumn: dbt_version
+
+		annotation SummarizationSetBy = Automatic
+
+	column total_nodes
+		dataType: int64
+		formatString: 0
+		lineageTag: 10c22bf4-e165-46c6-b775-e3de822f2972
+		sourceLineageTag: total_nodes
+		summarizeBy: sum
+		sourceColumn: total_nodes
+
+		annotation SummarizationSetBy = Automatic
+
+	column model_count
+		dataType: int64
+		formatString: 0
+		lineageTag: 8af99cac-7ce8-46d7-bb6c-5ef777a893b8
+		sourceLineageTag: model_count
+		summarizeBy: sum
+		sourceColumn: model_count
+
+		annotation SummarizationSetBy = Automatic
+
+	column test_count
+		dataType: int64
+		formatString: 0
+		lineageTag: f49f4b26-5a4e-492f-9bb8-739fec1177e5
+		sourceLineageTag: test_count
+		summarizeBy: sum
+		sourceColumn: test_count
+
+		annotation SummarizationSetBy = Automatic
+
+	column seed_count
+		dataType: int64
+		formatString: 0
+		lineageTag: 696bad07-3c8e-43ba-8ddc-36c891bc4bab
+		sourceLineageTag: seed_count
+		summarizeBy: sum
+		sourceColumn: seed_count
+
+		annotation SummarizationSetBy = Automatic
+
+	column snapshot_count
+		dataType: int64
+		formatString: 0
+		lineageTag: 3117d522-ede2-4ae8-898d-1317bf08cca6
+		sourceLineageTag: snapshot_count
+		summarizeBy: sum
+		sourceColumn: snapshot_count
+
+		annotation SummarizationSetBy = Automatic
+
+	column operation_count
+		dataType: int64
+		formatString: 0
+		lineageTag: 9aea8e78-e134-45c4-afce-a78db00c95da
+		sourceLineageTag: operation_count
+		summarizeBy: sum
+		sourceColumn: operation_count
+
+		annotation SummarizationSetBy = Automatic
+
+	column success_count
+		dataType: int64
+		formatString: 0
+		lineageTag: 73954ad7-b55f-4035-a90c-b39e23b59304
+		sourceLineageTag: success_count
+		summarizeBy: sum
+		sourceColumn: success_count
+
+		annotation SummarizationSetBy = Automatic
+
+	column error_count
+		dataType: int64
+		formatString: 0
+		lineageTag: f558fc80-5d84-42f7-b264-39143ada32a0
+		sourceLineageTag: error_count
+		summarizeBy: sum
+		sourceColumn: error_count
+
+		annotation SummarizationSetBy = Automatic
+
+	column skipped_count
+		dataType: int64
+		formatString: 0
+		lineageTag: 3c63cf17-572a-46d7-8b41-8445c242e601
+		sourceLineageTag: skipped_count
+		summarizeBy: sum
+		sourceColumn: skipped_count
+
+		annotation SummarizationSetBy = Automatic
+
+	column test_pass_count
+		dataType: int64
+		formatString: 0
+		lineageTag: e70eda8a-53eb-43fc-b63c-79cc92f03beb
+		sourceLineageTag: test_pass_count
+		summarizeBy: sum
+		sourceColumn: test_pass_count
+
+		annotation SummarizationSetBy = Automatic
+
+	column test_fail_count
+		dataType: int64
+		formatString: 0
+		lineageTag: d5d489ab-2962-4ebd-aed2-eb15e58ac184
+		sourceLineageTag: test_fail_count
+		summarizeBy: sum
+		sourceColumn: test_fail_count
+
+		annotation SummarizationSetBy = Automatic
+
+	column test_warn_count
+		dataType: int64
+		formatString: 0
+		lineageTag: 7356f16d-4f50-45bb-927f-b68bc779f7c4
+		sourceLineageTag: test_warn_count
+		summarizeBy: sum
+		sourceColumn: test_warn_count
+
+		annotation SummarizationSetBy = Automatic
+
+	column failure_count
+		dataType: int64
+		formatString: 0
+		lineageTag: b1f910af-6f50-4a29-8bb8-b8a0353ec7ce
+		sourceLineageTag: failure_count
+		summarizeBy: sum
+		sourceColumn: failure_count
+
+		annotation SummarizationSetBy = Automatic
+
+	column total_execution_time
+		dataType: double
+		formatString: 0.00
+		lineageTag: 53a78e81-7fd3-41cc-8876-5a246c466747
+		sourceLineageTag: total_execution_time
+		summarizeBy: sum
+		sourceColumn: total_execution_time
+
+		annotation SummarizationSetBy = Automatic
+
+	column total_execute_time
+		dataType: double
+		formatString: 0.00
+		lineageTag: 29b89b4f-f0f0-49d0-bc54-6043e54112e2
+		sourceLineageTag: total_execute_time
+		summarizeBy: sum
+		sourceColumn: total_execute_time
+
+		annotation SummarizationSetBy = Automatic
+
+	column total_compile_time
+		dataType: double
+		formatString: 0.00
+		lineageTag: b0f9566f-1dd0-4b14-823c-5091af5a0977
+		sourceLineageTag: total_compile_time
+		summarizeBy: sum
+		sourceColumn: total_compile_time
+
+		annotation SummarizationSetBy = Automatic
+
+	column avg_node_execute_time
+		dataType: double
+		formatString: 0.00
+		lineageTag: 7917c1e4-c729-4f47-8fa6-9068164575f9
+		sourceLineageTag: avg_node_execute_time
+		summarizeBy: none
+		sourceColumn: avg_node_execute_time
+
+		annotation SummarizationSetBy = Automatic
+
+	column wall_clock_seconds
+		dataType: double
+		formatString: 0.00
+		lineageTag: 69f13527-5d12-4d33-9f7d-f4ad3a136426
+		sourceLineageTag: wall_clock_seconds
+		summarizeBy: sum
+		sourceColumn: wall_clock_seconds
+
+		annotation SummarizationSetBy = Automatic
+
+	column thread_count
+		dataType: int64
+		formatString: 0
+		lineageTag: cf5617fe-ea48-4215-a7ba-6ef26e31f9ee
+		sourceLineageTag: thread_count
+		summarizeBy: none
+		sourceColumn: thread_count
+
+		annotation SummarizationSetBy = Automatic
+
+	column has_failure
+		dataType: int64
+		formatString: 0
+		lineageTag: a1b8107d-2676-422e-b9f6-fbbe1aa9054d
+		sourceLineageTag: has_failure
+		summarizeBy: sum
+		sourceColumn: has_failure
+
+		annotation SummarizationSetBy = Automatic
+
+	column success_rate
+		dataType: double
+		formatString: 0.00
+		lineageTag: f8aff820-7f53-410a-a63d-f1569e1f7cea
+		sourceLineageTag: success_rate
+		summarizeBy: none
+		sourceColumn: success_rate
+
+		annotation SummarizationSetBy = Automatic
+
+	column invocation_started_at
+		dataType: dateTime
+		formatString: General Date
+		lineageTag: 6dddd5bf-ba33-4404-bf64-1f797381a6b4
+		sourceLineageTag: invocation_started_at
+		summarizeBy: none
+		sourceColumn: invocation_started_at
+
+		annotation SummarizationSetBy = Automatic
+
+	column invocation_completed_at
+		dataType: dateTime
+		formatString: General Date
+		lineageTag: 32f35d67-7009-42c1-9e6b-3012e6e21258
+		sourceLineageTag: invocation_completed_at
+		summarizeBy: none
+		sourceColumn: invocation_completed_at
+
+		annotation SummarizationSetBy = Automatic
+
+	column generated_at
+		dataType: dateTime
+		formatString: General Date
+		lineageTag: 7ef67683-be1d-481c-8a64-6e68ef993ca9
+		sourceLineageTag: generated_at
+		summarizeBy: none
+		sourceColumn: generated_at
+
+		annotation SummarizationSetBy = Automatic
+
+	column dbt_loaded_at
+		dataType: dateTime
+		formatString: General Date
+		lineageTag: 6834bc35-4368-48af-8207-63d7e78d4e1c
+		sourceLineageTag: dbt_loaded_at
+		summarizeBy: none
+		sourceColumn: dbt_loaded_at
+
+		annotation SummarizationSetBy = Automatic
+
+	column event_year_date
+		dataType: string
+		lineageTag: 2f9f387a-3adc-44a3-b053-1b90201aeb61
+		sourceLineageTag: event_year_date
+		summarizeBy: none
+		sourceColumn: event_year_date
+
+		annotation SummarizationSetBy = Automatic
+
+	partition fct_dbt_invocation = entity
+		mode: directLake
+		source
+			entityName: fct_dbt_invocation
+			expressionSource: 'DirectLake - dbt_dataops_dwh'

--- a/projects/fabric/template/sandbox/dataops.SemanticModel/definition/tables/fct_dbt_node_execution.tmdl
+++ b/projects/fabric/template/sandbox/dataops.SemanticModel/definition/tables/fct_dbt_node_execution.tmdl
@@ -1,0 +1,337 @@
+table fct_dbt_node_execution
+	lineageTag: 9c8a3be7-23b6-4805-b7a5-9b885f12a01e
+	sourceLineageTag: [dbo].[fct_dbt_node_execution]
+
+	/// Count of dbt node execution rows
+	measure 'Total Node Executions' = COUNTROWS(fct_dbt_node_execution)
+		formatString: #,0
+		displayFolder: dbt \ Volume
+		lineageTag: ccc676f4-a5ce-4bd6-8948-925449fd65cf
+
+	/// Sum of successful dbt node counters
+	measure 'Successful Nodes' = SUM(fct_dbt_node_execution[is_success])
+		formatString: #,0
+		displayFolder: dbt \ Outcomes
+		lineageTag: a68690e4-20c3-4d8d-b71a-aef027912d7f
+
+	/// Sum of failed dbt node counters
+	measure 'Failed Nodes' = SUM(fct_dbt_node_execution[has_failure])
+		formatString: #,0
+		displayFolder: dbt \ Outcomes
+		lineageTag: b4693df5-97d0-485d-b2b2-b709c7c9aded
+
+	/// Successful nodes divided by total node executions
+	measure 'Success Rate' = DIVIDE([Successful Nodes],[Total Node Executions],0)
+		formatString: 0.0%
+		displayFolder: dbt \ Outcomes
+		lineageTag: 84553496-6577-43c7-906c-2d3dcec11bda
+
+	/// Average node execution time in seconds
+	measure 'Avg Execution Time (seconds)' = AVERAGE(fct_dbt_node_execution[execution_time])
+		formatString: #,0.00
+		displayFolder: dbt \ Timing
+		lineageTag: ea8a110b-866f-4fb4-9646-baa801a46a3e
+
+	/// Total node execution time in seconds
+	measure 'Total Execution Time (seconds)' = SUM(fct_dbt_node_execution[execution_time])
+		formatString: #,0.0
+		displayFolder: dbt \ Timing
+		lineageTag: df7aa13c-7c84-45a1-85ad-d42fdb1666e0
+
+	/// Count of distinct dbt invocation IDs
+	measure 'Total Invocations' = DISTINCTCOUNT(fct_dbt_node_execution[invocation_id])
+		formatString: #,0
+		displayFolder: dbt \ Volume
+		lineageTag: 74a1c790-29d1-47da-8a79-9d0bf09ecdf3
+
+	column node_execution_key
+		dataType: string
+		lineageTag: 77781010-e215-4a47-82d3-d0a796a6e0e2
+		sourceLineageTag: node_execution_key
+		summarizeBy: none
+		sourceColumn: node_execution_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column node_key
+		dataType: string
+		lineageTag: 031efb35-dde7-457f-9d63-403cbe17b3c1
+		sourceLineageTag: node_key
+		summarizeBy: none
+		sourceColumn: node_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column project_key
+		dataType: string
+		lineageTag: d8b67605-2b98-4759-93f4-6f1736d861eb
+		sourceLineageTag: project_key
+		summarizeBy: none
+		sourceColumn: project_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column resource_type_key
+		dataType: string
+		lineageTag: 8b93d045-dfde-4af5-94b2-080a8a4efcc7
+		sourceLineageTag: resource_type_key
+		summarizeBy: none
+		sourceColumn: resource_type_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column status_key
+		dataType: string
+		lineageTag: 8ee38970-bd4d-4ade-9ca9-eda206ecff80
+		sourceLineageTag: status_key
+		summarizeBy: none
+		sourceColumn: status_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column materialization_key
+		dataType: string
+		lineageTag: bcb25805-49c2-4ea6-8039-333b77466adb
+		sourceLineageTag: materialization_key
+		summarizeBy: none
+		sourceColumn: materialization_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column test_type_key
+		dataType: string
+		lineageTag: c82d619b-b906-4a13-a61f-84f4664fb4c1
+		sourceLineageTag: test_type_key
+		summarizeBy: none
+		sourceColumn: test_type_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column date_key
+		dataType: string
+		lineageTag: 0ec1ef41-26dc-4ecb-bf8f-dfe59424d5d8
+		sourceLineageTag: date_key
+		summarizeBy: none
+		sourceColumn: date_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column invocation_id
+		dataType: string
+		lineageTag: dda85fdf-fcac-46c3-ab00-406019211f5c
+		sourceLineageTag: invocation_id
+		summarizeBy: none
+		sourceColumn: invocation_id
+
+		annotation SummarizationSetBy = Automatic
+
+	column unique_id
+		dataType: string
+		lineageTag: ab102599-e054-457b-a9cf-9659ff4e40a1
+		sourceLineageTag: unique_id
+		summarizeBy: none
+		sourceColumn: unique_id
+
+		annotation SummarizationSetBy = Automatic
+
+	column command
+		dataType: string
+		lineageTag: 2951d6da-f7ad-4faa-8cdf-7ccaa40e10aa
+		sourceLineageTag: command
+		summarizeBy: none
+		sourceColumn: command
+
+		annotation SummarizationSetBy = Automatic
+
+	column thread_id
+		dataType: string
+		lineageTag: 75ff00fc-d8c7-4832-b550-94155cd3f76e
+		sourceLineageTag: thread_id
+		summarizeBy: none
+		sourceColumn: thread_id
+
+		annotation SummarizationSetBy = Automatic
+
+	column dbt_version
+		dataType: string
+		lineageTag: 9da0565e-7a34-4de8-8219-fffc7dae001c
+		sourceLineageTag: dbt_version
+		summarizeBy: none
+		sourceColumn: dbt_version
+
+		annotation SummarizationSetBy = Automatic
+
+	column execution_time
+		dataType: double
+		formatString: 0.00
+		lineageTag: be6fe92a-bbef-4299-ace8-cf4a86bc7f2f
+		sourceLineageTag: execution_time
+		summarizeBy: sum
+		sourceColumn: execution_time
+
+		annotation SummarizationSetBy = Automatic
+
+	column compile_time
+		dataType: double
+		formatString: 0.00
+		lineageTag: e4d7a78f-b190-442e-ae9b-14340537de95
+		sourceLineageTag: compile_time
+		summarizeBy: sum
+		sourceColumn: compile_time
+
+		annotation SummarizationSetBy = Automatic
+
+	column execute_time
+		dataType: double
+		formatString: 0.00
+		lineageTag: 4306acdc-4870-4177-81aa-a6c6136e92ce
+		sourceLineageTag: execute_time
+		summarizeBy: sum
+		sourceColumn: execute_time
+
+		annotation SummarizationSetBy = Automatic
+
+	column rows_affected
+		dataType: int64
+		formatString: 0
+		lineageTag: f9dc5602-16a0-475a-817f-45352a0af2ed
+		sourceLineageTag: rows_affected
+		summarizeBy: sum
+		sourceColumn: rows_affected
+
+		annotation SummarizationSetBy = Automatic
+
+	column failures
+		dataType: int64
+		formatString: 0
+		lineageTag: c42861c6-f9e8-44bd-a439-8ddb03195293
+		sourceLineageTag: failures
+		summarizeBy: sum
+		sourceColumn: failures
+
+		annotation SummarizationSetBy = Automatic
+
+	column is_success
+		dataType: int64
+		formatString: 0
+		lineageTag: 3298ec45-6e26-418e-803c-37d4902fdcd2
+		sourceLineageTag: is_success
+		summarizeBy: sum
+		sourceColumn: is_success
+
+		annotation SummarizationSetBy = Automatic
+
+	column is_error
+		dataType: int64
+		formatString: 0
+		lineageTag: 715aca54-d0e1-4526-a419-79109f07aa4a
+		sourceLineageTag: is_error
+		summarizeBy: sum
+		sourceColumn: is_error
+
+		annotation SummarizationSetBy = Automatic
+
+	column is_skipped
+		dataType: int64
+		formatString: 0
+		lineageTag: 78fa4e04-9449-457b-bf49-f73b20c4fe0f
+		sourceLineageTag: is_skipped
+		summarizeBy: sum
+		sourceColumn: is_skipped
+
+		annotation SummarizationSetBy = Automatic
+
+	column is_pass
+		dataType: int64
+		formatString: 0
+		lineageTag: 47edf938-b7b8-4cf5-b198-43e79825bb9f
+		sourceLineageTag: is_pass
+		summarizeBy: sum
+		sourceColumn: is_pass
+
+		annotation SummarizationSetBy = Automatic
+
+	column is_fail
+		dataType: int64
+		formatString: 0
+		lineageTag: 4f8731a9-09ba-47fa-b56b-fee3d7b86522
+		sourceLineageTag: is_fail
+		summarizeBy: sum
+		sourceColumn: is_fail
+
+		annotation SummarizationSetBy = Automatic
+
+	column is_warn
+		dataType: int64
+		formatString: 0
+		lineageTag: 35fb51f4-f854-4529-9279-c062c46b6a6a
+		sourceLineageTag: is_warn
+		summarizeBy: sum
+		sourceColumn: is_warn
+
+		annotation SummarizationSetBy = Automatic
+
+	column has_failure
+		dataType: int64
+		formatString: 0
+		lineageTag: 9ced43cc-5e02-46a7-af20-204a0dd0b2a8
+		sourceLineageTag: has_failure
+		summarizeBy: sum
+		sourceColumn: has_failure
+
+		annotation SummarizationSetBy = Automatic
+
+	column compile_started_at
+		dataType: dateTime
+		formatString: General Date
+		lineageTag: 8c6cc90d-3437-4479-8125-d9fcdbdd99de
+		sourceLineageTag: compile_started_at
+		summarizeBy: none
+		sourceColumn: compile_started_at
+
+		annotation SummarizationSetBy = Automatic
+
+	column execute_completed_at
+		dataType: dateTime
+		formatString: General Date
+		lineageTag: 422d1057-3686-4370-9c6c-9cccc483cf4c
+		sourceLineageTag: execute_completed_at
+		summarizeBy: none
+		sourceColumn: execute_completed_at
+
+		annotation SummarizationSetBy = Automatic
+
+	column generated_at
+		dataType: dateTime
+		formatString: General Date
+		lineageTag: 8f2c1ad2-91cd-4c89-be53-363c8e35cd7c
+		sourceLineageTag: generated_at
+		summarizeBy: none
+		sourceColumn: generated_at
+
+		annotation SummarizationSetBy = Automatic
+
+	column dbt_loaded_at
+		dataType: dateTime
+		formatString: General Date
+		lineageTag: cd17e761-80ee-4cb5-9141-8f1747c52ab1
+		sourceLineageTag: dbt_loaded_at
+		summarizeBy: none
+		sourceColumn: dbt_loaded_at
+
+		annotation SummarizationSetBy = Automatic
+
+	column event_year_date
+		dataType: string
+		lineageTag: fe8d6219-9c35-4cb5-9604-52639b855b13
+		sourceLineageTag: event_year_date
+		summarizeBy: none
+		sourceColumn: event_year_date
+
+		annotation SummarizationSetBy = Automatic
+
+	partition fct_dbt_node_execution = entity
+		mode: directLake
+		source
+			entityName: fct_dbt_node_execution
+			expressionSource: 'DirectLake - dbt_dataops_dwh'

--- a/projects/fabric/template/sandbox/dataops.SemanticModel/definition/tables/fct_delta_commit.tmdl
+++ b/projects/fabric/template/sandbox/dataops.SemanticModel/definition/tables/fct_delta_commit.tmdl
@@ -1,0 +1,177 @@
+table fct_delta_commit
+	lineageTag: ce87a80f-a8bf-4c33-825d-c97f40e75dd5
+	sourceLineageTag: [dbo].[fct_delta_commit]
+
+	/// Count of Delta commit rows
+	measure 'Total Commits' = COUNTROWS(fct_delta_commit)
+		formatString: #,0
+		displayFolder: Delta \ Commits
+		lineageTag: 72174692-b558-47d4-a5c7-b0323ecbdef7
+
+	/// Count of distinct Delta tables with commits
+	measure 'Tables Tracked' = DISTINCTCOUNT(fct_delta_commit[table_key])
+		formatString: #,0
+		displayFolder: Delta \ Commits
+		lineageTag: 6d0834fd-7a4a-4986-b256-678885843d6e
+
+	/// Sum of Delta output rows
+	measure 'Rows Written' = SUM(fct_delta_commit[num_output_rows])
+		formatString: #,0
+		displayFolder: Delta \ Commits
+		lineageTag: d8c718f0-0935-4213-bee0-aecca628bc4c
+
+	/// Sum of Delta files added
+	measure 'Files Added' = SUM(fct_delta_commit[num_added_files])
+		formatString: #,0
+		displayFolder: Delta \ Commits
+		lineageTag: fa0053ce-5bfe-4fe8-86cd-906e9241b0d0
+
+	column commit_key
+		dataType: string
+		lineageTag: 0dbb93fc-518e-4f5d-8f24-5a94e4eb9c0d
+		sourceLineageTag: commit_key
+		summarizeBy: none
+		sourceColumn: commit_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column table_key
+		dataType: string
+		lineageTag: e56e7fa2-fecd-4501-b670-de73f8c279b7
+		sourceLineageTag: table_key
+		summarizeBy: none
+		sourceColumn: table_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column operation_type_key
+		dataType: string
+		lineageTag: 6d9c7440-3448-4825-b291-e338e921023a
+		sourceLineageTag: operation_type_key
+		summarizeBy: none
+		sourceColumn: operation_type_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column date_key
+		dataType: string
+		lineageTag: 6885cbff-9852-4aa9-a791-91933ada4481
+		sourceLineageTag: date_key
+		summarizeBy: none
+		sourceColumn: date_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column version
+		dataType: int64
+		formatString: 0
+		lineageTag: ee4c7559-7192-4f55-8bda-92f2071b41ab
+		sourceLineageTag: version
+		summarizeBy: none
+		sourceColumn: version
+
+		annotation SummarizationSetBy = Automatic
+
+	column commit_timestamp
+		dataType: dateTime
+		formatString: General Date
+		lineageTag: de9c5727-029a-4503-92ef-45c3e6988423
+		sourceLineageTag: commit_timestamp
+		summarizeBy: none
+		sourceColumn: commit_timestamp
+
+		annotation SummarizationSetBy = Automatic
+
+	column num_output_rows
+		dataType: int64
+		formatString: 0
+		lineageTag: 65c47167-9af5-4569-9adc-5a351ee51a71
+		sourceLineageTag: num_output_rows
+		summarizeBy: sum
+		sourceColumn: num_output_rows
+
+		annotation SummarizationSetBy = Automatic
+
+	column num_added_files
+		dataType: int64
+		formatString: 0
+		lineageTag: 0cc5388f-5e46-4018-922f-759dbf4c9b22
+		sourceLineageTag: num_added_files
+		summarizeBy: sum
+		sourceColumn: num_added_files
+
+		annotation SummarizationSetBy = Automatic
+
+	column num_removed_files
+		dataType: int64
+		formatString: 0
+		lineageTag: 03ae9fe2-f7ee-403a-ad04-5f12543d0d8a
+		sourceLineageTag: num_removed_files
+		summarizeBy: sum
+		sourceColumn: num_removed_files
+
+		annotation SummarizationSetBy = Automatic
+
+	column num_output_bytes
+		dataType: int64
+		formatString: 0
+		lineageTag: a8d110d7-d0a2-4e06-8fbe-f49b89312adb
+		sourceLineageTag: num_output_bytes
+		summarizeBy: sum
+		sourceColumn: num_output_bytes
+
+		annotation SummarizationSetBy = Automatic
+
+	column execution_time_ms
+		dataType: int64
+		formatString: 0
+		lineageTag: a8008689-e56c-4a1f-b5d1-d24ecc561ef7
+		sourceLineageTag: execution_time_ms
+		summarizeBy: sum
+		sourceColumn: execution_time_ms
+
+		annotation SummarizationSetBy = Automatic
+
+	column is_blind_append
+		dataType: boolean
+		lineageTag: 4cd1744b-d343-4564-9547-87fb83055745
+		sourceLineageTag: is_blind_append
+		summarizeBy: none
+		sourceColumn: is_blind_append
+
+		annotation SummarizationSetBy = Automatic
+
+	column ingested_at
+		dataType: dateTime
+		formatString: General Date
+		lineageTag: ba25022a-5b76-478d-b776-0c1c280297df
+		sourceLineageTag: ingested_at
+		summarizeBy: none
+		sourceColumn: ingested_at
+
+		annotation SummarizationSetBy = Automatic
+
+	column dbt_loaded_at
+		dataType: dateTime
+		formatString: General Date
+		lineageTag: 98e48de8-8247-461e-a6ed-4bebdc8eeede
+		sourceLineageTag: dbt_loaded_at
+		summarizeBy: none
+		sourceColumn: dbt_loaded_at
+
+		annotation SummarizationSetBy = Automatic
+
+	column event_year_date
+		dataType: string
+		lineageTag: ccce2088-8e8d-4d97-8719-f6236fc8267e
+		sourceLineageTag: event_year_date
+		summarizeBy: none
+		sourceColumn: event_year_date
+
+		annotation SummarizationSetBy = Automatic
+
+	partition fct_delta_commit = entity
+		mode: directLake
+		source
+			entityName: fct_delta_commit
+			expressionSource: 'DirectLake - dbt_dataops_dwh'

--- a/projects/fabric/template/sandbox/dataops.SemanticModel/definition/tables/fct_delta_health.tmdl
+++ b/projects/fabric/template/sandbox/dataops.SemanticModel/definition/tables/fct_delta_health.tmdl
@@ -1,0 +1,258 @@
+table fct_delta_health
+	lineageTag: 92205afc-418a-46b9-a213-9d775893cf20
+	sourceLineageTag: [dbo].[fct_delta_health]
+
+	/// Count of Delta health assessment rows
+	measure 'Health Assessments' = COUNTROWS(fct_delta_health)
+		formatString: #,0
+		displayFolder: Delta \ Health
+		lineageTag: 6cc2d86f-c741-48dd-8578-b696ffbc29c5
+
+	/// Percent of health assessments with Healthy status
+	measure 'Healthy Table %' = DIVIDE(CALCULATE([Health Assessments], dim_delta_table_health_status[status] = "Healthy"), [Health Assessments], 0)
+		formatString: 0.0%
+		displayFolder: Delta \ Health
+		lineageTag: d6b676d6-d64e-4a98-8077-a49ef4f6d17b
+
+	/// Average days since latest commit
+	measure 'Avg Days Since Last Commit' = AVERAGE(fct_delta_health[days_since_last_commit])
+		formatString: #,0.0
+		displayFolder: Delta \ Health
+		lineageTag: f2d9fb9c-b9ab-4fcd-88bb-b021dc2033f0
+
+	column health_key
+		dataType: string
+		lineageTag: e0bd2b62-c8d8-4c75-be61-08e8b1c3991d
+		sourceLineageTag: health_key
+		summarizeBy: none
+		sourceColumn: health_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column table_key
+		dataType: string
+		lineageTag: 9570dba7-3bea-42dd-aa8c-80d1183b1d61
+		sourceLineageTag: table_key
+		summarizeBy: none
+		sourceColumn: table_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column date_key
+		dataType: string
+		lineageTag: 120e2f5f-d32d-4326-bc1e-ed96ffc799e5
+		sourceLineageTag: date_key
+		summarizeBy: none
+		sourceColumn: date_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column overall_status_key
+		dataType: string
+		lineageTag: f5c969e8-e782-4fb2-bdcd-95bb8b0faecf
+		sourceLineageTag: overall_status_key
+		summarizeBy: none
+		sourceColumn: overall_status_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column freshness_status_key
+		dataType: string
+		lineageTag: 24024ae4-e93c-47d2-a8b7-db63cadf6d52
+		sourceLineageTag: freshness_status_key
+		summarizeBy: none
+		sourceColumn: freshness_status_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column completeness_status_key
+		dataType: string
+		lineageTag: 7f1b05c5-f670-4955-b2c5-eb73871ad850
+		sourceLineageTag: completeness_status_key
+		summarizeBy: none
+		sourceColumn: completeness_status_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column most_common_operation_key
+		dataType: string
+		lineageTag: 5defe3f4-a049-4b3e-8491-7c94b4a9b578
+		sourceLineageTag: most_common_operation_key
+		summarizeBy: none
+		sourceColumn: most_common_operation_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column evaluation_timestamp
+		dataType: dateTime
+		formatString: General Date
+		lineageTag: a5735a70-422c-4c5d-b359-f8e248b404b8
+		sourceLineageTag: evaluation_timestamp
+		summarizeBy: none
+		sourceColumn: evaluation_timestamp
+
+		annotation SummarizationSetBy = Automatic
+
+	column last_commit_timestamp
+		dataType: dateTime
+		formatString: General Date
+		lineageTag: 60c4e0de-e758-4671-bf90-f983fe1af27b
+		sourceLineageTag: last_commit_timestamp
+		summarizeBy: none
+		sourceColumn: last_commit_timestamp
+
+		annotation SummarizationSetBy = Automatic
+
+	column predicted_next_commit
+		dataType: dateTime
+		formatString: General Date
+		lineageTag: 72de4091-8a8d-430c-84ca-0861dbbedbdd
+		sourceLineageTag: predicted_next_commit
+		summarizeBy: none
+		sourceColumn: predicted_next_commit
+
+		annotation SummarizationSetBy = Automatic
+
+	column median_commit_interval_seconds
+		dataType: double
+		formatString: 0.00
+		lineageTag: 0352f5f8-5958-4aec-9c70-070f62cfe9d5
+		sourceLineageTag: median_commit_interval_seconds
+		summarizeBy: none
+		sourceColumn: median_commit_interval_seconds
+
+		annotation SummarizationSetBy = Automatic
+
+	column p95_commit_interval_seconds
+		dataType: double
+		formatString: 0.00
+		lineageTag: 6a4cef1a-a2dc-406c-bccf-4cc27b5756fa
+		sourceLineageTag: p95_commit_interval_seconds
+		summarizeBy: none
+		sourceColumn: p95_commit_interval_seconds
+
+		annotation SummarizationSetBy = Automatic
+
+	column commits_in_last_24h
+		dataType: int64
+		formatString: 0
+		lineageTag: 79713d6c-a402-430f-abcb-3b4d3f77088d
+		sourceLineageTag: commits_in_last_24h
+		summarizeBy: sum
+		sourceColumn: commits_in_last_24h
+
+		annotation SummarizationSetBy = Automatic
+
+	column commits_in_last_7d
+		dataType: int64
+		formatString: 0
+		lineageTag: 2963c4ac-cdd0-40d8-8c3d-67bae3c0cb5b
+		sourceLineageTag: commits_in_last_7d
+		summarizeBy: sum
+		sourceColumn: commits_in_last_7d
+
+		annotation SummarizationSetBy = Automatic
+
+	column days_since_last_commit
+		dataType: double
+		formatString: 0.00
+		lineageTag: 619e4141-ccbe-43e9-bb8e-4e9a4d4e249f
+		sourceLineageTag: days_since_last_commit
+		summarizeBy: none
+		sourceColumn: days_since_last_commit
+
+		annotation SummarizationSetBy = Automatic
+
+	column daily_row_count_actual
+		dataType: int64
+		formatString: 0
+		lineageTag: fd969766-b089-4c33-a8c6-ec35f6b7ba7d
+		sourceLineageTag: daily_row_count_actual
+		summarizeBy: sum
+		sourceColumn: daily_row_count_actual
+
+		annotation SummarizationSetBy = Automatic
+
+	column daily_row_count_min_expected
+		dataType: int64
+		formatString: 0
+		lineageTag: 5accb37d-fbf3-42cb-b856-67426ddd5bd0
+		sourceLineageTag: daily_row_count_min_expected
+		summarizeBy: sum
+		sourceColumn: daily_row_count_min_expected
+
+		annotation SummarizationSetBy = Automatic
+
+	column daily_row_count_max_expected
+		dataType: int64
+		formatString: 0
+		lineageTag: 8004eadd-3679-4e7a-97ea-927ee629b1fa
+		sourceLineageTag: daily_row_count_max_expected
+		summarizeBy: sum
+		sourceColumn: daily_row_count_max_expected
+
+		annotation SummarizationSetBy = Automatic
+
+	column latest_version
+		dataType: int64
+		formatString: 0
+		lineageTag: cc391803-3d2e-4286-8865-0c3fe232d2b6
+		sourceLineageTag: latest_version
+		summarizeBy: none
+		sourceColumn: latest_version
+
+		annotation SummarizationSetBy = Automatic
+
+	column snapshot_date
+		dataType: string
+		lineageTag: 18ae8ce3-3d9d-40eb-92b5-367fb40a684e
+		sourceLineageTag: snapshot_date
+		summarizeBy: none
+		sourceColumn: snapshot_date
+
+		annotation SummarizationSetBy = Automatic
+
+	column optimize_count_7d
+		dataType: int64
+		formatString: 0
+		lineageTag: 7b3f1e6c-cfe1-49a2-aa32-3e6250e7baab
+		sourceLineageTag: optimize_count_7d
+		summarizeBy: sum
+		sourceColumn: optimize_count_7d
+
+		annotation SummarizationSetBy = Automatic
+
+	column vacuum_count_7d
+		dataType: int64
+		formatString: 0
+		lineageTag: 27d6a68e-2c3b-4334-812d-4849008f62b6
+		sourceLineageTag: vacuum_count_7d
+		summarizeBy: sum
+		sourceColumn: vacuum_count_7d
+
+		annotation SummarizationSetBy = Automatic
+
+	column dbt_loaded_at
+		dataType: dateTime
+		formatString: General Date
+		lineageTag: 7c2bb357-2af5-4ad4-9001-8598068305a1
+		sourceLineageTag: dbt_loaded_at
+		summarizeBy: none
+		sourceColumn: dbt_loaded_at
+
+		annotation SummarizationSetBy = Automatic
+
+	column event_year_date
+		dataType: string
+		lineageTag: 42032f2a-c0a6-4039-ac23-9ca9edf9ff04
+		sourceLineageTag: event_year_date
+		summarizeBy: none
+		sourceColumn: event_year_date
+
+		annotation SummarizationSetBy = Automatic
+
+	partition fct_delta_health = entity
+		mode: directLake
+		source
+			entityName: fct_delta_health
+			expressionSource: 'DirectLake - dbt_dataops_dwh'

--- a/projects/fabric/template/sandbox/dataops.SemanticModel/definition/tables/fct_delta_storage.tmdl
+++ b/projects/fabric/template/sandbox/dataops.SemanticModel/definition/tables/fct_delta_storage.tmdl
@@ -1,0 +1,139 @@
+table fct_delta_storage
+	lineageTag: 30f13707-c99a-4bb8-97fd-4e0e6578f3fa
+	sourceLineageTag: [dbo].[fct_delta_storage]
+
+	/// Total tracked Delta storage in GB
+	measure 'Total Storage (GB)' = SUM(fct_delta_storage[size_in_gb])
+		formatString: #,0.00
+		displayFolder: Delta \ Storage
+		lineageTag: fd935674-8990-4029-8c4b-6aa671835f98
+
+	/// Total tracked Delta files
+	measure 'Total Files' = SUM(fct_delta_storage[num_files])
+		formatString: #,0
+		displayFolder: Delta \ Storage
+		lineageTag: 6b38fcf4-907d-4139-bc90-96e8b5d25106
+
+	/// Storage in GB on the latest selected date
+	measure 'Latest Storage (GB)' = VAR _d = MAX(fct_delta_storage[date_key]) RETURN CALCULATE(SUM(fct_delta_storage[size_in_gb]), fct_delta_storage[date_key] = _d)
+		formatString: #,0.00
+		displayFolder: Delta \ Storage
+		lineageTag: 283b0d75-5967-4e85-85f4-2fb9254f8f90
+
+	/// File count on the latest selected date
+	measure 'Latest File Count' = VAR _d = MAX(fct_delta_storage[date_key]) RETURN CALCULATE(SUM(fct_delta_storage[num_files]), fct_delta_storage[date_key] = _d)
+		formatString: #,0
+		displayFolder: Delta \ Storage
+		lineageTag: 76166b43-8631-44aa-b62d-083539096bf5
+
+	column storage_key
+		dataType: string
+		lineageTag: ca3db710-a68e-4ae5-80f7-38baf4be76fa
+		sourceLineageTag: storage_key
+		summarizeBy: none
+		sourceColumn: storage_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column table_key
+		dataType: string
+		lineageTag: 6f0848cd-489d-49be-af42-b0d0d97f671a
+		sourceLineageTag: table_key
+		summarizeBy: none
+		sourceColumn: table_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column date_key
+		dataType: string
+		lineageTag: 011eb1b3-e114-47b9-968b-02df3623704e
+		sourceLineageTag: date_key
+		summarizeBy: none
+		sourceColumn: date_key
+
+		annotation SummarizationSetBy = Automatic
+
+	column num_files
+		dataType: int64
+		formatString: 0
+		lineageTag: 06180be7-39cc-424b-9aa6-20114241828a
+		sourceLineageTag: num_files
+		summarizeBy: sum
+		sourceColumn: num_files
+
+		annotation SummarizationSetBy = Automatic
+
+	column size_in_bytes
+		dataType: int64
+		formatString: 0
+		lineageTag: 58c3fcf4-3871-47ea-89cd-f517b740825c
+		sourceLineageTag: size_in_bytes
+		summarizeBy: sum
+		sourceColumn: size_in_bytes
+
+		annotation SummarizationSetBy = Automatic
+
+	column size_in_gb
+		dataType: double
+		formatString: 0.00
+		lineageTag: 24b56e79-821a-4a23-ba5b-60e8c40ab325
+		sourceLineageTag: size_in_gb
+		summarizeBy: sum
+		sourceColumn: size_in_gb
+
+		annotation SummarizationSetBy = Automatic
+
+	column created_at
+		dataType: dateTime
+		formatString: General Date
+		lineageTag: 5cd60ad6-5831-4872-961d-44a4eb735695
+		sourceLineageTag: created_at
+		summarizeBy: none
+		sourceColumn: created_at
+
+		annotation SummarizationSetBy = Automatic
+
+	column last_modified
+		dataType: dateTime
+		formatString: General Date
+		lineageTag: 7040cbe1-c0b6-4365-95cc-6dbf7f983c1b
+		sourceLineageTag: last_modified
+		summarizeBy: none
+		sourceColumn: last_modified
+
+		annotation SummarizationSetBy = Automatic
+
+	column ingested_at
+		dataType: dateTime
+		formatString: General Date
+		lineageTag: bd09f8f3-aed4-4093-a735-992a915aac9b
+		sourceLineageTag: ingested_at
+		summarizeBy: none
+		sourceColumn: ingested_at
+
+		annotation SummarizationSetBy = Automatic
+
+	column dbt_loaded_at
+		dataType: dateTime
+		formatString: General Date
+		lineageTag: 1cee5cee-cced-43c4-9b13-964fd42b249a
+		sourceLineageTag: dbt_loaded_at
+		summarizeBy: none
+		sourceColumn: dbt_loaded_at
+
+		annotation SummarizationSetBy = Automatic
+
+	column event_year_date
+		dataType: string
+		lineageTag: ed69d303-c806-45bf-b308-1392b8396be2
+		sourceLineageTag: event_year_date
+		summarizeBy: none
+		sourceColumn: event_year_date
+
+		annotation SummarizationSetBy = Automatic
+
+	partition fct_delta_storage = entity
+		mode: directLake
+		source
+			entityName: fct_delta_storage
+			expressionSource: 'DirectLake - dbt_dataops_dwh'

--- a/projects/spark-dbt/dbt-adventureworks/project.json
+++ b/projects/spark-dbt/dbt-adventureworks/project.json
@@ -33,6 +33,13 @@
     "lint": {
       "executor": "nx:run-commands",
       "cache": false,
+      "dependsOn": [
+        {
+          "target": "init",
+          "projects": ["spark-dbt"],
+          "params": "ignore"
+        }
+      ],
       "inputs": [
         "{projectRoot}/**/*",
         "{workspaceRoot}/projects/spark-dbt/.scripts/lint-dbt.sh",

--- a/projects/spark-dbt/dbt-dataops/.sqlfluffignore
+++ b/projects/spark-dbt/dbt-dataops/.sqlfluffignore
@@ -1,0 +1,5 @@
+# One-big-table (obt_*) models use dbt_utils.star, which introspects live
+# relations at compile time. They can only be templated when the upstream
+# tables already exist + a Spark session is up, so sqlfluff's result is
+# non-deterministic (skipped vs fixed). Exclude them so lint is deterministic.
+obt_*.sql

--- a/projects/spark-dbt/dbt-dataops/README.md
+++ b/projects/spark-dbt/dbt-dataops/README.md
@@ -1,10 +1,16 @@
 ## Dimensional modelling dbt project: `dataops`
 
-A Kimball STAR schema for monitoring Delta Lake table operations. This dbt project transforms raw inventory data — commit history, table snapshots, health KPIs, and OpenLineage events — into a set of fact and dimension tables for analytics.
+In the `dbt_dataops_dwh` warehouse:
 
-### What's in this repo?
+1. **Delta Lake operations star** (`*_delta_*`) — monitors Delta table operations:
+   commit history, table snapshots, health KPIs, and OpenLineage lineage.
 
-This project sources data from the `dataops_inventory` schema (populated by the `spark-scala` ETL framework) and models it into a dimensional warehouse in `dbt_dataops_dwh`.
+2. **dbt observability star** (`*_dbt_*`) — turns the project's own execution
+   telemetry (`dbt_node_executions`, emitted by `dbt-runner-lib` on every local and
+   Fabric run) into analytics-ready facts, dimensions, and fully-denormalised OBTs.
+
+Both source from the `dataops_inventory` schema (populated by the `spark-scala` ETL
+framework and the dbt runner) and model into `dbt_dataops_dwh`.
 
 The Entity-Relationship Diagram is available in [`erd/full_model.dbml`](erd/full_model.dbml).
 

--- a/projects/spark-dbt/dbt-dataops/erd/full_model.dbml
+++ b/projects/spark-dbt/dbt-dataops/erd/full_model.dbml
@@ -1,5 +1,5 @@
 //Tables (based on the selection criteria)
-//--configured at schema: spark_catalog.dbt_dataops_dwh
+//--configured at schema: dbt_dataops_dwh.dbt_dataops_dwh
 Table dim_date {
   "date_key" "string" [pk, note: "Date key in yyyyMMdd format."]
   "full_date" "date"
@@ -15,7 +15,83 @@ Table dim_date {
 
   Note: "Conformed calendar date dimension."
 }
-//--configured at schema: spark_catalog.dbt_dataops_dwh
+//--configured at schema: dbt_dataops_dwh.dbt_dataops_dwh
+Table dim_dbt_materialization {
+  "materialization_key" "string" [pk, note: "Surrogate key (SHA-256 of materialized). Unknown member at '-1'."]
+  "materialized" "string" [pk, note: "dbt materialization name."]
+  "storage_class" "string" [note: "Whether the materialization persists as a view, table, or none."]
+  "is_persisted" "boolean" [note: "True if the materialization writes a durable relation."]
+  "is_rebuilt_each_run" "boolean" [note: "True if the relation is fully rebuilt on every run."]
+  "description" "string"
+
+  Note: "Reference dimension for dbt materializations (view, table, incremental, snapshot, seed, ...). Carries a '-1' unknown member."
+}
+//--configured at schema: dbt_dataops_dwh.dbt_dataops_dwh
+Table dim_dbt_node {
+  "node_key" "string" [pk, note: "Surrogate key (SHA-256 of unique_id). Unknown member at '-1'."]
+  "unique_id" "string" [pk, note: "dbt node unique_id (business key), e.g. model.dataops.dim_date."]
+  "project" "string" [note: "Owning dbt project."]
+  "resource_type" "string" [note: "dbt resource type of the node."]
+  "package_name" "string"
+  "node_name" "string" [note: "Node name (without unique_id namespacing)."]
+  "alias" "string"
+  "database_name" "string"
+  "schema_name" "string"
+  "relation_name" "string"
+  "original_file_path" "string"
+  "materialized" "string" [note: "Latest materialization of the node."]
+  "node_layer" "string" [note: "Model folder (staging/marts/...) for models, else the resource_type."]
+  "test_type" "string" [note: "For tests: the test macro name; NULL otherwise."]
+  "tested_column" "string" [note: "For column-level tests: the tested column; NULL otherwise."]
+  "is_test" "boolean" [note: "True if the node is a test."]
+
+  Note: "Central conformed dimension: one row per dbt node (unique_id) with its latest attributes. Type 1 (latest-wins); SCD2 history via snapshot is a future enhancement. Carries a '-1' unknown member."
+}
+//--configured at schema: dbt_dataops_dwh.dbt_dataops_dwh
+Table dim_dbt_project {
+  "project_key" "string" [pk, note: "Surrogate key (SHA-256 of project). Unknown member at '-1'."]
+  "project" "string" [pk, note: "dbt project name (business key), e.g. dbt-dataops."]
+  "project_domain" "string" [note: "Short domain slug (project name without the dbt- prefix)."]
+  "project_description" "string" [note: "Human-readable description of the project's purpose."]
+  "is_demo" "boolean" [note: "True if the project is a demo/sample project."]
+
+  Note: "Conformed dimension of dbt projects observed in the telemetry. Type 1. Carries a '-1' unknown member."
+}
+//--configured at schema: dbt_dataops_dwh.dbt_dataops_dwh
+Table dim_dbt_resource_type {
+  "resource_type_key" "string" [pk, note: "Surrogate key (SHA-256 of resource_type). Unknown member at '-1'."]
+  "resource_type" "string" [pk, note: "dbt resource type name."]
+  "resource_category" "string" [note: "Coarse grouping of the resource type."]
+  "is_executable" "boolean" [note: "True if the resource runs SQL against the warehouse."]
+  "is_test" "boolean" [note: "True if the resource is a data/unit test."]
+  "is_data" "boolean" [note: "True if the resource represents source/seed data."]
+  "description" "string"
+
+  Note: "Reference dimension classifying dbt resource types (model, test, seed, snapshot, operation, ...). Carries a '-1' unknown member."
+}
+//--configured at schema: dbt_dataops_dwh.dbt_dataops_dwh
+Table dim_dbt_status {
+  "status_key" "string" [pk, note: "Surrogate key (SHA-256 of status). Unknown member at '-1'."]
+  "status" "string" [pk, note: "Raw dbt node status string."]
+  "status_group" "string" [note: "Conformed status grouping."]
+  "is_passing" "boolean" [note: "True if the node completed successfully (model success or test pass)."]
+  "is_failure" "boolean" [note: "True if the node failed (model error or test fail)."]
+  "severity_rank" "int" [note: "Ordinal severity (0 = ok, higher = worse). -1 for the unknown member."]
+  "description" "string"
+
+  Note: "Reference dimension conforming heterogeneous model (success/error/skipped) and test (pass/fail/warn/error/skipped) statuses into a single health classification. Carries a '-1' unknown member."
+}
+//--configured at schema: dbt_dataops_dwh.dbt_dataops_dwh
+Table dim_dbt_test_type {
+  "test_type_key" "string" [pk, note: "Surrogate key (SHA-256 of test_type). Unknown member at '-1'."]
+  "test_type" "string" [pk, note: "Test macro name from test_metadata (e.g. not_null)."]
+  "test_family" "string" [note: "Quality dimension the test asserts."]
+  "package" "string" [note: "Package providing the test (dbt_core, dbt_utils, custom, unknown)."]
+  "is_generic" "boolean" [note: "True for generic (schema) tests."]
+
+  Note: "Reference dimension for data-test types (not_null, unique, relationships, accepted_values, dbt_utils.*, custom). Carries a '-1' unknown member."
+}
+//--configured at schema: dbt_dataops_dwh.dbt_dataops_dwh
 Table dim_delta_table {
   "__pk" "string" [pk, note: "Surrogate key unique per SCD2 version. SHA-256 of (table_fqn, row_effective_start)."]
   "table_fqn" "string" [note: "Business key: fully qualified table name (database.table)."]
@@ -40,7 +116,7 @@ Table dim_delta_table {
 
   Note: "Central table dimension with mixed SCD1/SCD2 tracking. SCD2 columns (clustering_columns, table_properties, min_reader_version, min_writer_version) are version-specific. SCD1 columns (table_id, location, format, partition_columns) are propagated to all versions."
 }
-//--configured at schema: spark_catalog.dbt_dataops_dwh
+//--configured at schema: dbt_dataops_dwh.dbt_dataops_dwh
 Table dim_delta_table_health_status {
   "health_status_key" "string" [pk, note: "Surrogate key (SHA-256 of status name)."]
   "status" "string" [pk, note: "Health status: Healthy, Training, or Unhealthy."]
@@ -49,7 +125,7 @@ Table dim_delta_table_health_status {
 
   Note: "Static enum dimension for health status values."
 }
-//--configured at schema: spark_catalog.dbt_dataops_dwh
+//--configured at schema: dbt_dataops_dwh.dbt_dataops_dwh
 Table dim_delta_table_operation_type {
   "operation_type_key" "string" [pk, note: "Surrogate key (SHA-256 of operation name)."]
   "operation" "string" [pk, note: "Delta Lake operation name."]
@@ -60,7 +136,93 @@ Table dim_delta_table_operation_type {
 
   Note: "Reference dimension classifying Delta Lake operation types."
 }
-//--configured at schema: spark_catalog.dbt_dataops_dwh
+//--configured at schema: dbt_dataops_dwh.dbt_dataops_dwh
+Table fct_dbt_invocation {
+  "invocation_key" "string" [pk, note: "Surrogate key (SHA-256 of invocation_id)."]
+  "project_key" "string" [note: "FK to dim_dbt_project."]
+  "date_key" "string" [note: "FK to dim_date (invocation date)."]
+  "invocation_id" "string" [pk, note: "Degenerate dimension: the dbt invocation UUID."]
+  "command" "string" [note: "Degenerate dimension: dbt command (build, seed, ...)."]
+  "dbt_version" "string"
+  "total_nodes" "bigint" [note: "Count of node executions in the invocation (additive)."]
+  "model_count" "bigint"
+  "test_count" "bigint"
+  "seed_count" "bigint"
+  "snapshot_count" "bigint"
+  "operation_count" "bigint"
+  "success_count" "bigint"
+  "error_count" "bigint"
+  "skipped_count" "bigint"
+  "test_pass_count" "bigint"
+  "test_fail_count" "bigint"
+  "test_warn_count" "bigint"
+  "failure_count" "bigint" [note: "Count of failed nodes (model errors + test fails) (additive)."]
+  "total_execution_time" "double"
+  "total_execute_time" "double"
+  "total_compile_time" "double"
+  "avg_node_execute_time" "double"
+  "wall_clock_seconds" "bigint" [note: "Elapsed seconds between first execute start and last execute completion."]
+  "thread_count" "bigint"
+  "has_failure" "int"
+  "success_rate" "double" [note: "success_count / total_nodes. NON-ADDITIVE \u2014 recompute from counts when aggregating."]
+  "invocation_started_at" "timestamp"
+  "invocation_completed_at" "timestamp"
+  "generated_at" "timestamp"
+  "dbt_loaded_at" "timestamp"
+  "event_year_date" "string" [note: "Hive partition key (yyyyMMdd) from dbt run time."]
+
+  Note: "Summary fact: one row per dbt invocation (command run). Grain: one row per invocation_id. Count and timing measures are additive; success_rate is non-additive (a ratio \u2014 do not SUM; recompute from counts)."
+}
+//--configured at schema: dbt_dataops_dwh.dbt_dataops_dwh
+Table fct_dbt_node_dependency {
+  "dependency_key" "string" [pk, note: "Surrogate key (SHA-256 of node_unique_id + depends_on_unique_id)."]
+  "node_key" "string" [note: "FK to dim_dbt_node (the dependent node)."]
+  "depends_on_node_key" "string" [note: "FK to dim_dbt_node (the upstream node)."]
+  "project_key" "string" [note: "FK to dim_dbt_project."]
+  "date_key" "string" [note: "FK to dim_date."]
+  "node_unique_id" "string"
+  "depends_on_unique_id" "string"
+  "dbt_loaded_at" "timestamp"
+  "event_year_date" "string" [note: "Hive partition key (yyyyMMdd) from dbt run time."]
+
+  Note: "Bridge fact of the current dbt DAG (latest invocation per project). Grain: one edge per (node_unique_id, depends_on_unique_id). Rebuilt in full each run; depends_on_node_key resolves to the unknown member when the upstream node never executed on its own (e.g. a source)."
+}
+//--configured at schema: dbt_dataops_dwh.dbt_dataops_dwh
+Table fct_dbt_node_execution {
+  "node_execution_key" "string" [pk, note: "Surrogate key (SHA-256 of invocation_id + unique_id)."]
+  "node_key" "string" [note: "FK to dim_dbt_node."]
+  "project_key" "string" [note: "FK to dim_dbt_project."]
+  "resource_type_key" "string" [note: "FK to dim_dbt_resource_type."]
+  "status_key" "string" [note: "FK to dim_dbt_status."]
+  "materialization_key" "string" [note: "FK to dim_dbt_materialization."]
+  "test_type_key" "string" [note: "FK to dim_dbt_test_type (unknown member for non-test nodes)."]
+  "date_key" "string" [note: "FK to dim_date (run date)."]
+  "invocation_id" "string" [note: "Degenerate dimension: the dbt invocation UUID."]
+  "unique_id" "string" [note: "Degenerate dimension: the dbt node unique_id (grain key)."]
+  "command" "string"
+  "thread_id" "string"
+  "dbt_version" "string"
+  "execution_time" "double" [note: "Total node execution time in seconds (additive)."]
+  "compile_time" "double" [note: "Compile-phase time in seconds (additive)."]
+  "execute_time" "double" [note: "Execute-phase time in seconds (additive)."]
+  "rows_affected" "bigint"
+  "failures" "bigint"
+  "is_success" "int" [note: "1 if the node succeeded (model/seed/snapshot/operation), else 0."]
+  "is_error" "int"
+  "is_skipped" "int"
+  "is_pass" "int"
+  "is_fail" "int"
+  "is_warn" "int"
+  "has_failure" "int" [note: "1 if the node errored or a test failed, else 0."]
+  "compile_started_at" "timestamp"
+  "execute_completed_at" "timestamp"
+  "generated_at" "timestamp"
+  "dbt_loaded_at" "timestamp"
+  "event_year_date" "string" [note: "Hive partition key (yyyyMMdd) from dbt run time."]
+
+  Note: "Atomic fact: one row per dbt node execution within an invocation. Grain: one row per (invocation_id, unique_id). Status counters are additive; timing measures are additive. rows_affected/failures are adapter-reported and frequently NULL on the fabricspark adapter."
+}
+//--configured at schema: dbt_dataops_dwh.dbt_dataops_dwh
 Table fct_delta_commit {
   "commit_key" "string" [pk, note: "Surrogate key (SHA-256 of table_fqn + version)."]
   "table_key" "string" [note: "FK to dim_delta_table."]
@@ -75,10 +237,12 @@ Table fct_delta_commit {
   "execution_time_ms" "bigint"
   "is_blind_append" "boolean"
   "ingested_at" "timestamp"
+  "dbt_loaded_at" "timestamp" [note: "Spark write timestamp when this row was materialized by dbt."]
+  "event_year_date" "string" [note: "Hive partition key in yyyyMMdd format, derived from current_timestamp() at dbt run time."]
 
   Note: "Fact table capturing individual Delta Lake commits. Grain: one row per table per commit version."
 }
-//--configured at schema: spark_catalog.dbt_dataops_dwh
+//--configured at schema: dbt_dataops_dwh.dbt_dataops_dwh
 Table fct_delta_health {
   "health_key" "string" [pk, note: "Surrogate key (SHA-256 of table_fqn + snapshot_date + evaluation_timestamp)."]
   "table_key" "string" [note: "FK to dim_delta_table."]
@@ -102,10 +266,12 @@ Table fct_delta_health {
   "snapshot_date" "string"
   "optimize_count_7d" "bigint"
   "vacuum_count_7d" "bigint"
+  "dbt_loaded_at" "timestamp" [note: "Spark write timestamp when this row was materialized by dbt."]
+  "event_year_date" "string" [note: "Hive partition key in yyyyMMdd format, derived from current_timestamp() at dbt run time."]
 
   Note: "Fact table capturing daily health KPI assessments. Grain: one row per table per snapshot date."
 }
-//--configured at schema: spark_catalog.dbt_dataops_dwh
+//--configured at schema: dbt_dataops_dwh.dbt_dataops_dwh
 Table fct_delta_lineage_dependency {
   "lineage_key" "string" [pk, note: "Surrogate key for the lineage edge."]
   "source_table_key" "string" [note: "FK to dim_delta_table for source dataset."]
@@ -114,10 +280,12 @@ Table fct_delta_lineage_dependency {
   "first_seen_timestamp" "timestamp"
   "last_seen_timestamp" "timestamp"
   "event_count" "bigint"
+  "dbt_loaded_at" "timestamp" [note: "Spark write timestamp when this row was materialized by dbt."]
+  "event_year_date" "string" [note: "Hive partition key in yyyyMMdd format, derived from current_timestamp() at dbt run time."]
 
   Note: "Fact table capturing table-level data lineage edges from OpenLineage. Grain: one edge per source\u2192target per job per day."
 }
-//--configured at schema: spark_catalog.dbt_dataops_dwh
+//--configured at schema: dbt_dataops_dwh.dbt_dataops_dwh
 Table fct_delta_storage {
   "storage_key" "string" [pk, note: "Surrogate key (SHA-256 of table_fqn + snapshot_date)."]
   "table_key" "string" [note: "FK to dim_delta_table."]
@@ -128,10 +296,186 @@ Table fct_delta_storage {
   "created_at" "timestamp"
   "last_modified" "timestamp"
   "ingested_at" "timestamp"
+  "dbt_loaded_at" "timestamp" [note: "Spark write timestamp when this row was materialized by dbt."]
+  "event_year_date" "string" [note: "Hive partition key in yyyyMMdd format, derived from current_timestamp() at dbt run time."]
 
   Note: "Fact table capturing daily table storage metrics. Grain: one row per table per snapshot date."
 }
-//--configured at schema: spark_catalog.dbt_dataops_dwh
+//--configured at schema: dbt_dataops_dwh.dbt_dataops_dwh
+Table obt_dbt_invocation {
+  "invocation_key" "string" [pk, note: "Surrogate key inherited from fct_dbt_invocation."]
+  "invocation_id" "string"
+  "command" "string"
+  "dbt_version" "string"
+  "total_nodes" "bigint"
+  "model_count" "bigint"
+  "test_count" "bigint"
+  "seed_count" "bigint"
+  "snapshot_count" "bigint"
+  "operation_count" "bigint"
+  "success_count" "bigint"
+  "error_count" "bigint"
+  "skipped_count" "bigint"
+  "test_pass_count" "bigint"
+  "test_fail_count" "bigint"
+  "test_warn_count" "bigint"
+  "failure_count" "bigint"
+  "total_execution_time" "double"
+  "total_execute_time" "double"
+  "total_compile_time" "double"
+  "avg_node_execute_time" "double"
+  "wall_clock_seconds" "bigint"
+  "thread_count" "bigint"
+  "has_failure" "int"
+  "success_rate" "double"
+  "invocation_started_at" "timestamp"
+  "invocation_completed_at" "timestamp"
+  "generated_at" "timestamp"
+  "dbt_loaded_at" "timestamp"
+  "event_year_date" "string"
+  "project" "string"
+  "project_domain" "string"
+  "project_description" "string"
+  "is_demo" "boolean"
+  "full_date" "date"
+  "year" "int"
+  "quarter" "int"
+  "month" "int"
+  "month_name" "string"
+  "day_of_month" "int"
+  "day_of_week" "int"
+  "day_name" "string"
+  "week_of_year" "int"
+  "is_weekend" "boolean"
+
+  Note: "Fully denormalised one-big-table of dbt invocations joined to project and date. Grain: one row per invocation_id."
+}
+//--configured at schema: dbt_dataops_dwh.dbt_dataops_dwh
+Table obt_dbt_node_execution {
+  "node_execution_key" "string" [pk, note: "Surrogate key inherited from fct_dbt_node_execution."]
+  "invocation_id" "string"
+  "unique_id" "string"
+  "command" "string"
+  "thread_id" "string"
+  "dbt_version" "string"
+  "execution_time" "double"
+  "compile_time" "double"
+  "execute_time" "double"
+  "rows_affected" "bigint"
+  "failures" "bigint"
+  "is_success" "int"
+  "is_error" "int"
+  "is_skipped" "int"
+  "is_pass" "int"
+  "is_fail" "int"
+  "is_warn" "int"
+  "has_failure" "int"
+  "compile_started_at" "timestamp"
+  "execute_completed_at" "timestamp"
+  "generated_at" "timestamp"
+  "dbt_loaded_at" "timestamp"
+  "event_year_date" "string"
+  "project" "string"
+  "resource_type" "string"
+  "package_name" "string"
+  "node_name" "string"
+  "alias" "string"
+  "database_name" "string"
+  "schema_name" "string"
+  "relation_name" "string"
+  "original_file_path" "string"
+  "materialized" "string"
+  "node_layer" "string"
+  "test_type" "string"
+  "tested_column" "string"
+  "is_test" "boolean"
+  "project_domain" "string"
+  "project_description" "string"
+  "is_demo" "boolean"
+  "resource_category" "string"
+  "is_executable" "boolean"
+  "is_data" "boolean"
+  "status" "string"
+  "status_group" "string"
+  "is_passing" "boolean"
+  "is_failure" "boolean"
+  "severity_rank" "int"
+  "storage_class" "string"
+  "is_persisted" "boolean"
+  "is_rebuilt_each_run" "boolean"
+  "test_family" "string"
+  "package" "string"
+  "is_generic" "boolean"
+  "full_date" "date"
+  "year" "int"
+  "quarter" "int"
+  "month" "int"
+  "month_name" "string"
+  "day_of_month" "int"
+  "day_of_week" "int"
+  "day_name" "string"
+  "week_of_year" "int"
+  "is_weekend" "boolean"
+
+  Note: "Fully denormalised one-big-table of dbt node executions joined to every conformed dimension (node, project, resource_type, status, materialization, test_type, date). Grain: one row per (invocation_id, unique_id). Built via dbt_utils.star \u2014 see assert_obt_rowcount_matches_fact for fan-out protection."
+}
+//--configured at schema: dbt_dataops_dwh.dbt_dataops_dwh
+Table stg_dbt_node_dependency {
+  "invocation_id" "string" [pk]
+  "node_unique_id" "string" [note: "The dependent (parent) dbt node unique_id."]
+  "depends_on_unique_id" "string" [note: "The upstream (child) dbt node unique_id this node depends on."]
+  "project" "string" [note: "dbt project name."]
+  "run_date_key" "string"
+
+  Note: "Exploded dbt DAG edges: one row per (invocation_id, node_unique_id, depends_on_unique_id) derived from the depends_on_nodes array."
+}
+//--configured at schema: dbt_dataops_dwh.dbt_dataops_dwh
+Table stg_dbt_node_executions {
+  "invocation_id" "string" [pk, note: "UUID of the dbt invocation (one command run)."]
+  "unique_id" "string" [note: "Stable dbt node identity (e.g. model.dataops.dim_date)."]
+  "project" "string" [note: "dbt project name."]
+  "command" "string"
+  "dbt_version" "string"
+  "thread_id" "string"
+  "generated_at" "timestamp"
+  "resource_type" "string" [note: "dbt resource type: model, test, seed, snapshot, operation."]
+  "package_name" "string"
+  "node_name" "string"
+  "alias" "string"
+  "database_name" "string"
+  "schema_name" "string"
+  "relation_name" "string"
+  "original_file_path" "string"
+  "materialized" "string"
+  "node_layer" "string"
+  "test_type" "string"
+  "tested_column" "string"
+  "adapter_message" "string"
+  "status" "string" [note: "Raw node outcome string."]
+  "is_success" "boolean"
+  "is_error" "boolean"
+  "is_skipped" "boolean"
+  "is_pass" "boolean"
+  "is_fail" "boolean"
+  "is_warn" "boolean"
+  "has_failure" "boolean"
+  "is_test" "boolean"
+  "execution_time" "double"
+  "compile_time" "double"
+  "execute_time" "double"
+  "compile_started_at" "timestamp"
+  "compile_completed_at" "timestamp"
+  "execute_started_at" "timestamp"
+  "execute_completed_at" "timestamp"
+  "rows_affected" "bigint"
+  "failures" "bigint"
+  "depends_on_nodes" "array<string>"
+  "run_date_key" "string" [note: "Run date in yyyyMMdd, from coalesce(execute_completed_at, generated_at)."]
+  "event_year_month" "string"
+
+  Note: "Cleaned, typed, and deduplicated dbt node-execution telemetry from the dataops_inventory.dbt_node_executions source. One row per (invocation_id, unique_id) \u2014 the latest result per node per invocation. Extracts test type / tested column / adapter message from JSON and derives run date key, node layer, and boolean status flags."
+}
+//--configured at schema: dbt_dataops_dwh.dbt_dataops_dwh
 Table stg_delta_commit_history {
   "table_fqn" "string" [pk, note: "Fully qualified table name (database.table)."]
   "database_name" "string"
@@ -159,7 +503,7 @@ Table stg_delta_commit_history {
 
   Note: "Cleaned and typed Delta Lake commit history entries."
 }
-//--configured at schema: spark_catalog.dbt_dataops_dwh
+//--configured at schema: dbt_dataops_dwh.dbt_dataops_dwh
 Table stg_delta_kpi_results {
   "table_fqn" "string" [pk, note: "Fully qualified table name."]
   "overall_status" "string" [note: "Overall health status: Healthy, Unhealthy, or Training."]
@@ -185,7 +529,7 @@ Table stg_delta_kpi_results {
 
   Note: "Cleaned health KPI assessment results."
 }
-//--configured at schema: spark_catalog.dbt_dataops_dwh
+//--configured at schema: dbt_dataops_dwh.dbt_dataops_dwh
 Table stg_delta_lineage {
   "source_namespace" "string" [pk]
   "source_name" "string" [note: "Source dataset name/path."]
@@ -199,7 +543,7 @@ Table stg_delta_lineage {
 
   Note: "Table-level lineage edges extracted from OpenLineage COMPLETE events."
 }
-//--configured at schema: spark_catalog.dbt_dataops_dwh
+//--configured at schema: dbt_dataops_dwh.dbt_dataops_dwh
 Table stg_delta_table_snapshots {
   "table_fqn" "string" [pk, note: "Fully qualified table name (business key for dim_delta_table)."]
   "database_name" "string"
@@ -228,6 +572,19 @@ Table stg_delta_table_snapshots {
   Note: "Deduplicated table metadata snapshots with SCD hash columns. One row per table per day."
 }
 //Refs (based on the DBT Relationship Tests)
+Ref: fct_dbt_invocation."date_key" > dim_date."date_key"
+Ref: fct_dbt_invocation."project_key" > dim_dbt_project."project_key"
+Ref: fct_dbt_node_dependency."date_key" > dim_date."date_key"
+Ref: fct_dbt_node_dependency."depends_on_node_key" > dim_dbt_node."node_key"
+Ref: fct_dbt_node_dependency."node_key" > dim_dbt_node."node_key"
+Ref: fct_dbt_node_dependency."project_key" > dim_dbt_project."project_key"
+Ref: fct_dbt_node_execution."date_key" > dim_date."date_key"
+Ref: fct_dbt_node_execution."materialization_key" > dim_dbt_materialization."materialization_key"
+Ref: fct_dbt_node_execution."node_key" > dim_dbt_node."node_key"
+Ref: fct_dbt_node_execution."project_key" > dim_dbt_project."project_key"
+Ref: fct_dbt_node_execution."resource_type_key" > dim_dbt_resource_type."resource_type_key"
+Ref: fct_dbt_node_execution."status_key" > dim_dbt_status."status_key"
+Ref: fct_dbt_node_execution."test_type_key" > dim_dbt_test_type."test_type_key"
 Ref: fct_delta_commit."date_key" > dim_date."date_key"
 Ref: fct_delta_commit."operation_type_key" > dim_delta_table_operation_type."operation_type_key"
 Ref: fct_delta_commit."table_key" > dim_delta_table."__pk"

--- a/projects/spark-dbt/dbt-dataops/models/marts/_dbt_observability.yml
+++ b/projects/spark-dbt/dbt-dataops/models/marts/_dbt_observability.yml
@@ -1,0 +1,397 @@
+version: 2
+
+models:
+  # ---------------------------------------------------------------------------
+  # Dimensions
+  # ---------------------------------------------------------------------------
+  - name: dim_dbt_project
+    description: "Conformed dimension of dbt projects observed in the telemetry. Type 1. Carries a '-1' unknown member."
+    tests:
+      - has_rows
+      - has_unknown_member:
+          arguments:
+            key_column: project_key
+    columns:
+      - name: project_key
+        description: "Surrogate key (SHA-256 of project). Unknown member at '-1'."
+        tests:
+          - unique
+          - not_null
+      - name: project
+        description: "dbt project name (business key), e.g. dbt-dataops."
+        tests:
+          - unique
+          - not_null
+      - name: project_domain
+        description: "Short domain slug (project name without the dbt- prefix)."
+      - name: project_description
+        description: "Human-readable description of the project's purpose."
+      - name: is_demo
+        description: "True if the project is a demo/sample project."
+
+  - name: dim_dbt_resource_type
+    description: "Reference dimension classifying dbt resource types (model, test, seed, snapshot, operation, ...). Carries a '-1' unknown member."
+    tests:
+      - has_rows
+      - has_unknown_member:
+          arguments:
+            key_column: resource_type_key
+    columns:
+      - name: resource_type_key
+        description: "Surrogate key (SHA-256 of resource_type). Unknown member at '-1'."
+        tests:
+          - unique
+          - not_null
+      - name: resource_type
+        description: "dbt resource type name."
+        tests:
+          - unique
+          - not_null
+      - name: resource_category
+        description: "Coarse grouping of the resource type."
+        tests:
+          - accepted_values:
+              arguments:
+                values: ["transformation", "test", "data", "maintenance", "documentation", "semantic", "unknown"]
+      - name: is_executable
+        description: "True if the resource runs SQL against the warehouse."
+      - name: is_test
+        description: "True if the resource is a data/unit test."
+      - name: is_data
+        description: "True if the resource represents source/seed data."
+
+  - name: dim_dbt_status
+    description: "Reference dimension conforming heterogeneous model (success/error/skipped) and test (pass/fail/warn/error/skipped) statuses into a single health classification. Carries a '-1' unknown member."
+    tests:
+      - has_rows
+      - has_unknown_member:
+          arguments:
+            key_column: status_key
+    columns:
+      - name: status_key
+        description: "Surrogate key (SHA-256 of status). Unknown member at '-1'."
+        tests:
+          - unique
+          - not_null
+      - name: status
+        description: "Raw dbt node status string."
+        tests:
+          - unique
+          - not_null
+      - name: status_group
+        description: "Conformed status grouping."
+        tests:
+          - accepted_values:
+              arguments:
+                values: ["passed", "failed", "skipped", "warned", "unknown"]
+      - name: is_passing
+        description: "True if the node completed successfully (model success or test pass)."
+      - name: is_failure
+        description: "True if the node failed (model error or test fail)."
+      - name: severity_rank
+        description: "Ordinal severity (0 = ok, higher = worse). -1 for the unknown member."
+
+  - name: dim_dbt_materialization
+    description: "Reference dimension for dbt materializations (view, table, incremental, snapshot, seed, ...). Carries a '-1' unknown member."
+    tests:
+      - has_rows
+      - has_unknown_member:
+          arguments:
+            key_column: materialization_key
+    columns:
+      - name: materialization_key
+        description: "Surrogate key (SHA-256 of materialized). Unknown member at '-1'."
+        tests:
+          - unique
+          - not_null
+      - name: materialized
+        description: "dbt materialization name."
+        tests:
+          - unique
+          - not_null
+      - name: storage_class
+        description: "Whether the materialization persists as a view, table, or none."
+        tests:
+          - accepted_values:
+              arguments:
+                values: ["view", "table", "none", "unknown"]
+      - name: is_persisted
+        description: "True if the materialization writes a durable relation."
+      - name: is_rebuilt_each_run
+        description: "True if the relation is fully rebuilt on every run."
+
+  - name: dim_dbt_test_type
+    description: "Reference dimension for data-test types (not_null, unique, relationships, accepted_values, dbt_utils.*, custom). Carries a '-1' unknown member."
+    tests:
+      - has_rows
+      - has_unknown_member:
+          arguments:
+            key_column: test_type_key
+    columns:
+      - name: test_type_key
+        description: "Surrogate key (SHA-256 of test_type). Unknown member at '-1'."
+        tests:
+          - unique
+          - not_null
+      - name: test_type
+        description: "Test macro name from test_metadata (e.g. not_null)."
+        tests:
+          - unique
+          - not_null
+      - name: test_family
+        description: "Quality dimension the test asserts."
+        tests:
+          - accepted_values:
+              arguments:
+                values: ["completeness", "uniqueness", "referential_integrity", "validity", "consistency", "other", "unknown"]
+      - name: package
+        description: "Package providing the test (dbt_core, dbt_utils, custom, unknown)."
+      - name: is_generic
+        description: "True for generic (schema) tests."
+
+  - name: dim_dbt_node
+    description: "Central conformed dimension: one row per dbt node (unique_id) with its latest attributes. Type 1 (latest-wins); SCD2 history via snapshot is a future enhancement. Carries a '-1' unknown member."
+    tests:
+      - has_rows
+      - has_unknown_member:
+          arguments:
+            key_column: node_key
+    columns:
+      - name: node_key
+        description: "Surrogate key (SHA-256 of unique_id). Unknown member at '-1'."
+        tests:
+          - unique
+          - not_null
+      - name: unique_id
+        description: "dbt node unique_id (business key), e.g. model.dataops.dim_date."
+        tests:
+          - unique
+          - not_null
+      - name: project
+        description: "Owning dbt project."
+        tests:
+          - not_null
+      - name: resource_type
+        description: "dbt resource type of the node."
+      - name: node_name
+        description: "Node name (without unique_id namespacing)."
+      - name: node_layer
+        description: "Model folder (staging/marts/...) for models, else the resource_type."
+      - name: materialized
+        description: "Latest materialization of the node."
+      - name: test_type
+        description: "For tests: the test macro name; NULL otherwise."
+      - name: tested_column
+        description: "For column-level tests: the tested column; NULL otherwise."
+      - name: is_test
+        description: "True if the node is a test."
+
+  # ---------------------------------------------------------------------------
+  # Facts
+  # ---------------------------------------------------------------------------
+  - name: fct_dbt_node_execution
+    description: >-
+      Atomic fact: one row per dbt node execution within an invocation.
+      Grain: one row per (invocation_id, unique_id). Status counters are additive;
+      timing measures are additive. rows_affected/failures are adapter-reported and
+      frequently NULL on the fabricspark adapter.
+    tests:
+      - has_rows
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - invocation_id
+              - unique_id
+    columns:
+      - name: node_execution_key
+        description: "Surrogate key (SHA-256 of invocation_id + unique_id)."
+        tests:
+          - unique
+          - not_null
+      - name: node_key
+        description: "FK to dim_dbt_node."
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_dbt_node')
+                field: node_key
+      - name: project_key
+        description: "FK to dim_dbt_project."
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_dbt_project')
+                field: project_key
+      - name: resource_type_key
+        description: "FK to dim_dbt_resource_type."
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_dbt_resource_type')
+                field: resource_type_key
+      - name: status_key
+        description: "FK to dim_dbt_status."
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_dbt_status')
+                field: status_key
+      - name: materialization_key
+        description: "FK to dim_dbt_materialization."
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_dbt_materialization')
+                field: materialization_key
+      - name: test_type_key
+        description: "FK to dim_dbt_test_type (unknown member for non-test nodes)."
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_dbt_test_type')
+                field: test_type_key
+      - name: date_key
+        description: "FK to dim_date (run date)."
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_date')
+                field: date_key
+      - name: invocation_id
+        description: "Degenerate dimension: the dbt invocation UUID."
+        tests:
+          - not_null
+      - name: unique_id
+        description: "Degenerate dimension: the dbt node unique_id (grain key)."
+        tests:
+          - not_null
+      - name: execution_time
+        description: "Total node execution time in seconds (additive)."
+      - name: execute_time
+        description: "Execute-phase time in seconds (additive)."
+      - name: compile_time
+        description: "Compile-phase time in seconds (additive)."
+      - name: is_success
+        description: "1 if the node succeeded (model/seed/snapshot/operation), else 0."
+      - name: has_failure
+        description: "1 if the node errored or a test failed, else 0."
+      - name: event_year_date
+        description: "Hive partition key (yyyyMMdd) from dbt run time."
+        tests:
+          - not_null
+
+  - name: fct_dbt_invocation
+    description: >-
+      Summary fact: one row per dbt invocation (command run).
+      Grain: one row per invocation_id. Count and timing measures are additive;
+      success_rate is non-additive (a ratio — do not SUM; recompute from counts).
+    tests:
+      - has_rows
+    columns:
+      - name: invocation_key
+        description: "Surrogate key (SHA-256 of invocation_id)."
+        tests:
+          - unique
+          - not_null
+      - name: invocation_id
+        description: "Degenerate dimension: the dbt invocation UUID."
+        tests:
+          - unique
+          - not_null
+      - name: project_key
+        description: "FK to dim_dbt_project."
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_dbt_project')
+                field: project_key
+      - name: date_key
+        description: "FK to dim_date (invocation date)."
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_date')
+                field: date_key
+      - name: command
+        description: "Degenerate dimension: dbt command (build, seed, ...)."
+        tests:
+          - not_null
+      - name: total_nodes
+        description: "Count of node executions in the invocation (additive)."
+        tests:
+          - not_null
+      - name: failure_count
+        description: "Count of failed nodes (model errors + test fails) (additive)."
+      - name: wall_clock_seconds
+        description: "Elapsed seconds between first execute start and last execute completion."
+      - name: success_rate
+        description: "success_count / total_nodes. NON-ADDITIVE — recompute from counts when aggregating."
+      - name: event_year_date
+        description: "Hive partition key (yyyyMMdd) from dbt run time."
+        tests:
+          - not_null
+
+  - name: fct_dbt_node_dependency
+    description: >-
+      Bridge fact of the current dbt DAG (latest invocation per project).
+      Grain: one edge per (node_unique_id, depends_on_unique_id). Rebuilt in full
+      each run; depends_on_node_key resolves to the unknown member when the upstream
+      node never executed on its own (e.g. a source).
+    tests:
+      - has_rows
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - node_unique_id
+              - depends_on_unique_id
+    columns:
+      - name: dependency_key
+        description: "Surrogate key (SHA-256 of node_unique_id + depends_on_unique_id)."
+        tests:
+          - unique
+          - not_null
+      - name: node_key
+        description: "FK to dim_dbt_node (the dependent node)."
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_dbt_node')
+                field: node_key
+      - name: depends_on_node_key
+        description: "FK to dim_dbt_node (the upstream node)."
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_dbt_node')
+                field: node_key
+      - name: project_key
+        description: "FK to dim_dbt_project."
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_dbt_project')
+                field: project_key
+      - name: date_key
+        description: "FK to dim_date."
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_date')
+                field: date_key
+      - name: event_year_date
+        description: "Hive partition key (yyyyMMdd) from dbt run time."
+        tests:
+          - not_null

--- a/projects/spark-dbt/dbt-dataops/models/marts/_dbt_observability_obt.yml
+++ b/projects/spark-dbt/dbt-dataops/models/marts/_dbt_observability_obt.yml
@@ -1,0 +1,30 @@
+version: 2
+
+models:
+  - name: obt_dbt_node_execution
+    description: >-
+      Fully denormalised one-big-table of dbt node executions joined to every
+      conformed dimension (node, project, resource_type, status, materialization,
+      test_type, date). Grain: one row per (invocation_id, unique_id). Built via
+      dbt_utils.star — see assert_obt_rowcount_matches_fact for fan-out protection.
+    tests:
+      - has_rows
+    columns:
+      - name: node_execution_key
+        description: "Surrogate key inherited from fct_dbt_node_execution."
+        tests:
+          - unique
+          - not_null
+
+  - name: obt_dbt_invocation
+    description: >-
+      Fully denormalised one-big-table of dbt invocations joined to project and
+      date. Grain: one row per invocation_id.
+    tests:
+      - has_rows
+    columns:
+      - name: invocation_key
+        description: "Surrogate key inherited from fct_dbt_invocation."
+        tests:
+          - unique
+          - not_null

--- a/projects/spark-dbt/dbt-dataops/models/marts/dim_dbt_materialization.sql
+++ b/projects/spark-dbt/dbt-dataops/models/marts/dim_dbt_materialization.sql
@@ -1,0 +1,52 @@
+{{
+    config(
+        materialized='table',
+        file_format='delta',
+        location_root='none'
+    )
+}}
+
+WITH members AS (
+    SELECT
+        materialized,
+        storage_class,
+        cast(is_persisted AS boolean) AS is_persisted,
+        cast(is_rebuilt_each_run AS boolean) AS is_rebuilt_each_run,
+        description
+    FROM (
+        VALUES
+        ('view', 'view', TRUE, TRUE, 'A logical view recreated on every run'),
+        ('table', 'table', TRUE, TRUE, 'A physical table fully rebuilt on every run'),
+        ('incremental', 'table', TRUE, FALSE, 'A physical table appended/merged incrementally'),
+        ('snapshot', 'table', TRUE, FALSE, 'An SCD2 history table updated in place'),
+        ('seed', 'table', TRUE, TRUE, 'A table loaded from a CSV seed'),
+        ('materialized_view', 'view', TRUE, FALSE, 'A materialized view refreshed by the engine'),
+        ('ephemeral', 'none', FALSE, TRUE, 'An inlined CTE that is never persisted'),
+        ('test', 'none', FALSE, TRUE, 'A transient test query, not persisted'),
+        ('unit_test', 'none', FALSE, TRUE, 'A transient unit-test query, not persisted'),
+        ('operation', 'none', FALSE, TRUE, 'A hook or operation that persists no relation')
+    ) AS t (materialized, storage_class, is_persisted, is_rebuilt_each_run, description)
+),
+
+final AS (
+    SELECT
+        sha2(materialized, 256) AS materialization_key,
+        materialized,
+        storage_class,
+        is_persisted,
+        is_rebuilt_each_run,
+        description
+    FROM members
+
+    UNION ALL
+
+    SELECT
+        '-1' AS materialization_key,
+        'Unknown' AS materialized,
+        'unknown' AS storage_class,
+        FALSE AS is_persisted,
+        FALSE AS is_rebuilt_each_run,
+        'Unknown member for unresolved materializations' AS description
+)
+
+SELECT * FROM final

--- a/projects/spark-dbt/dbt-dataops/models/marts/dim_dbt_node.sql
+++ b/projects/spark-dbt/dbt-dataops/models/marts/dim_dbt_node.sql
@@ -1,0 +1,70 @@
+{{
+    config(
+        materialized='table',
+        file_format='delta',
+        location_root='none'
+    )
+}}
+
+{#
+    Type 1 dimension: one row per dbt node (unique_id), latest attributes win.
+    Node attributes (materialized, path, layer) rarely change; SCD2 history via a
+    snapshot is a documented future enhancement.
+#}
+
+WITH ranked AS (
+    SELECT
+        *,
+        row_number() OVER (
+            PARTITION BY unique_id
+            ORDER BY generated_at DESC, execute_completed_at DESC
+        ) AS _rn
+    FROM {{ ref('stg_dbt_node_executions') }}
+),
+
+latest AS (
+    SELECT * FROM ranked WHERE _rn = 1
+),
+
+final AS (
+    SELECT
+        sha2(unique_id, 256) AS node_key,
+        unique_id,
+        project,
+        resource_type,
+        package_name,
+        node_name,
+        alias,
+        database_name,
+        schema_name,
+        relation_name,
+        original_file_path,
+        materialized,
+        node_layer,
+        test_type,
+        tested_column,
+        is_test
+    FROM latest
+
+    UNION ALL
+
+    SELECT
+        '-1' AS node_key,
+        'Unknown' AS unique_id,
+        'Unknown' AS project,
+        'Unknown' AS resource_type,
+        cast(NULL AS string) AS package_name,
+        'Unknown' AS node_name,
+        cast(NULL AS string) AS alias,
+        cast(NULL AS string) AS database_name,
+        cast(NULL AS string) AS schema_name,
+        cast(NULL AS string) AS relation_name,
+        cast(NULL AS string) AS original_file_path,
+        cast(NULL AS string) AS materialized,
+        'unknown' AS node_layer,
+        cast(NULL AS string) AS test_type,
+        cast(NULL AS string) AS tested_column,
+        FALSE AS is_test
+)
+
+SELECT * FROM final

--- a/projects/spark-dbt/dbt-dataops/models/marts/dim_dbt_project.sql
+++ b/projects/spark-dbt/dbt-dataops/models/marts/dim_dbt_project.sql
@@ -1,0 +1,59 @@
+{{
+    config(
+        materialized='table',
+        file_format='delta',
+        location_root='none'
+    )
+}}
+
+WITH observed AS (
+    SELECT DISTINCT project
+    FROM {{ ref('stg_dbt_node_executions') }}
+    WHERE project IS NOT NULL
+),
+
+enrichment AS (
+    SELECT
+        project,
+        project_domain,
+        project_description,
+        cast(is_demo AS boolean) AS is_demo
+    FROM (
+        VALUES
+        ('dbt-adventureworks', 'adventureworks', 'Kimball STAR demo over AdventureWorks', TRUE),
+        ('dbt-dataops', 'dataops', 'Delta Lake KPI + dbt observability warehouse', TRUE),
+        ('dbt-jaffle-shop', 'jaffle-shop', 'Jaffle Shop toolchain smoke test', TRUE),
+        ('dbt-reddit', 'reddit', 'Reddit ETL analytics warehouse', TRUE)
+    ) AS t (project, project_domain, project_description, is_demo)
+),
+
+joined AS (
+    SELECT
+        observed.project,
+        coalesce(enrichment.project_domain, regexp_replace(observed.project, '^dbt-', '')) AS project_domain,
+        coalesce(enrichment.project_description, 'Unclassified dbt project') AS project_description,
+        coalesce(enrichment.is_demo, FALSE) AS is_demo
+    FROM observed
+    LEFT JOIN enrichment ON observed.project = enrichment.project
+),
+
+final AS (
+    SELECT
+        sha2(project, 256) AS project_key,
+        project,
+        project_domain,
+        project_description,
+        is_demo
+    FROM joined
+
+    UNION ALL
+
+    SELECT
+        '-1' AS project_key,
+        'Unknown' AS project,
+        'unknown' AS project_domain,
+        'Unknown member for unresolved projects' AS project_description,
+        FALSE AS is_demo
+)
+
+SELECT * FROM final

--- a/projects/spark-dbt/dbt-dataops/models/marts/dim_dbt_resource_type.sql
+++ b/projects/spark-dbt/dbt-dataops/models/marts/dim_dbt_resource_type.sql
@@ -1,0 +1,55 @@
+{{
+    config(
+        materialized='table',
+        file_format='delta',
+        location_root='none'
+    )
+}}
+
+WITH members AS (
+    SELECT
+        resource_type,
+        resource_category,
+        cast(is_executable AS boolean) AS is_executable,
+        cast(is_test AS boolean) AS is_test,
+        cast(is_data AS boolean) AS is_data,
+        description
+    FROM (
+        VALUES
+        ('model', 'transformation', TRUE, FALSE, FALSE, 'A SQL transformation materialized as a relation'),
+        ('snapshot', 'transformation', TRUE, FALSE, FALSE, 'An SCD2 snapshot capturing slowly changing history'),
+        ('seed', 'data', FALSE, FALSE, TRUE, 'A CSV file loaded as a table'),
+        ('test', 'test', TRUE, TRUE, FALSE, 'A data test asserting a quality constraint'),
+        ('unit_test', 'test', TRUE, TRUE, FALSE, 'A unit test validating model logic with mock inputs'),
+        ('operation', 'maintenance', TRUE, FALSE, FALSE, 'A hook or run-operation macro invocation'),
+        ('analysis', 'documentation', FALSE, FALSE, FALSE, 'A compiled-but-not-run analytical query'),
+        ('source', 'data', FALSE, FALSE, TRUE, 'An externally managed source relation'),
+        ('exposure', 'documentation', FALSE, FALSE, FALSE, 'A downstream consumer of dbt models'),
+        ('metric', 'semantic', FALSE, FALSE, FALSE, 'A semantic-layer metric definition')
+    ) AS t (resource_type, resource_category, is_executable, is_test, is_data, description)
+),
+
+final AS (
+    SELECT
+        sha2(resource_type, 256) AS resource_type_key,
+        resource_type,
+        resource_category,
+        is_executable,
+        is_test,
+        is_data,
+        description
+    FROM members
+
+    UNION ALL
+
+    SELECT
+        '-1' AS resource_type_key,
+        'Unknown' AS resource_type,
+        'unknown' AS resource_category,
+        FALSE AS is_executable,
+        FALSE AS is_test,
+        FALSE AS is_data,
+        'Unknown member for unresolved resource types' AS description
+)
+
+SELECT * FROM final

--- a/projects/spark-dbt/dbt-dataops/models/marts/dim_dbt_status.sql
+++ b/projects/spark-dbt/dbt-dataops/models/marts/dim_dbt_status.sql
@@ -1,0 +1,52 @@
+{{
+    config(
+        materialized='table',
+        file_format='delta',
+        location_root='none'
+    )
+}}
+
+WITH members AS (
+    SELECT
+        status,
+        status_group,
+        cast(is_passing AS boolean) AS is_passing,
+        cast(is_failure AS boolean) AS is_failure,
+        cast(severity_rank AS int) AS severity_rank,
+        description
+    FROM (
+        VALUES
+        ('success', 'passed', TRUE, FALSE, 0, 'Model, seed, snapshot, or operation completed successfully'),
+        ('pass', 'passed', TRUE, FALSE, 0, 'Data test passed'),
+        ('warn', 'warned', FALSE, FALSE, 1, 'Data test raised a warning (soft failure)'),
+        ('skipped', 'skipped', FALSE, FALSE, 2, 'Node skipped because an upstream node failed'),
+        ('fail', 'failed', FALSE, TRUE, 3, 'Data test failed'),
+        ('error', 'failed', FALSE, TRUE, 3, 'Node raised an execution error'),
+        ('runtime error', 'failed', FALSE, TRUE, 3, 'Node raised a runtime error')
+    ) AS t (status, status_group, is_passing, is_failure, severity_rank, description)
+),
+
+final AS (
+    SELECT
+        sha2(status, 256) AS status_key,
+        status,
+        status_group,
+        is_passing,
+        is_failure,
+        severity_rank,
+        description
+    FROM members
+
+    UNION ALL
+
+    SELECT
+        '-1' AS status_key,
+        'Unknown' AS status,
+        'unknown' AS status_group,
+        FALSE AS is_passing,
+        FALSE AS is_failure,
+        -1 AS severity_rank,
+        'Unknown member for unresolved statuses' AS description
+)
+
+SELECT * FROM final

--- a/projects/spark-dbt/dbt-dataops/models/marts/dim_dbt_test_type.sql
+++ b/projects/spark-dbt/dbt-dataops/models/marts/dim_dbt_test_type.sql
@@ -1,0 +1,66 @@
+{{
+    config(
+        materialized='table',
+        file_format='delta',
+        location_root='none'
+    )
+}}
+
+WITH observed AS (
+    SELECT DISTINCT test_type
+    FROM {{ ref('stg_dbt_node_executions') }}
+    WHERE test_type IS NOT NULL
+),
+
+enrichment AS (
+    SELECT
+        test_type,
+        test_family,
+        package
+    FROM (
+        VALUES
+        ('not_null', 'completeness', 'dbt_core'),
+        ('unique', 'uniqueness', 'dbt_core'),
+        ('relationships', 'referential_integrity', 'dbt_core'),
+        ('accepted_values', 'validity', 'dbt_core'),
+        ('unique_combination_of_columns', 'uniqueness', 'dbt_utils'),
+        ('expression_is_true', 'validity', 'dbt_utils'),
+        ('accepted_range', 'validity', 'dbt_utils'),
+        ('not_null_proportion', 'completeness', 'dbt_utils'),
+        ('equal_rowcount', 'consistency', 'dbt_utils'),
+        ('fewer_rows_than', 'consistency', 'dbt_utils'),
+        ('mutually_exclusive_ranges', 'validity', 'dbt_utils'),
+        ('has_rows', 'completeness', 'custom'),
+        ('has_unknown_member', 'referential_integrity', 'custom')
+    ) AS t (test_type, test_family, package)
+),
+
+joined AS (
+    SELECT
+        observed.test_type,
+        coalesce(enrichment.test_family, 'other') AS test_family,
+        coalesce(enrichment.package, 'custom') AS package
+    FROM observed
+    LEFT JOIN enrichment ON observed.test_type = enrichment.test_type
+),
+
+final AS (
+    SELECT
+        sha2(test_type, 256) AS test_type_key,
+        test_type,
+        test_family,
+        package,
+        TRUE AS is_generic
+    FROM joined
+
+    UNION ALL
+
+    SELECT
+        '-1' AS test_type_key,
+        'Unknown' AS test_type,
+        'unknown' AS test_family,
+        'unknown' AS package,
+        FALSE AS is_generic
+)
+
+SELECT * FROM final

--- a/projects/spark-dbt/dbt-dataops/models/marts/fct_dbt_invocation.sql
+++ b/projects/spark-dbt/dbt-dataops/models/marts/fct_dbt_invocation.sql
@@ -1,0 +1,114 @@
+{{
+    config(
+        materialized='incremental',
+        incremental_strategy='append',
+        file_format='delta',
+        location_root='none',
+        on_schema_change='append_new_columns',
+        partition_by=['event_year_date']
+    )
+}}
+
+-- Grain: one row per invocation_id — a single dbt command run (e.g. one `build`).
+
+WITH src AS (
+    SELECT * FROM {{ ref('stg_dbt_node_executions') }}
+    {% if is_incremental() %}
+        WHERE generated_at >= (SELECT max(generated_at) FROM {{ this }})
+    {% endif %}
+),
+
+agg AS (
+    SELECT
+        invocation_id,
+        project,
+        command,
+        dbt_version,
+        min(generated_at) AS generated_at,
+
+        count(*) AS total_nodes,
+        sum(CASE WHEN resource_type = 'model' THEN 1 ELSE 0 END) AS model_count,
+        sum(CASE WHEN resource_type = 'test' THEN 1 ELSE 0 END) AS test_count,
+        sum(CASE WHEN resource_type = 'seed' THEN 1 ELSE 0 END) AS seed_count,
+        sum(CASE WHEN resource_type = 'snapshot' THEN 1 ELSE 0 END) AS snapshot_count,
+        sum(CASE WHEN resource_type = 'operation' THEN 1 ELSE 0 END) AS operation_count,
+
+        sum(CASE WHEN is_success THEN 1 ELSE 0 END) AS success_count,
+        sum(CASE WHEN is_error THEN 1 ELSE 0 END) AS error_count,
+        sum(CASE WHEN is_skipped THEN 1 ELSE 0 END) AS skipped_count,
+        sum(CASE WHEN is_pass THEN 1 ELSE 0 END) AS test_pass_count,
+        sum(CASE WHEN is_fail THEN 1 ELSE 0 END) AS test_fail_count,
+        sum(CASE WHEN is_warn THEN 1 ELSE 0 END) AS test_warn_count,
+        sum(CASE WHEN has_failure THEN 1 ELSE 0 END) AS failure_count,
+
+        sum(execution_time) AS total_execution_time,
+        sum(execute_time) AS total_execute_time,
+        sum(compile_time) AS total_compile_time,
+        avg(execute_time) AS avg_node_execute_time,
+
+        count(DISTINCT thread_id) AS thread_count,
+        min(execute_started_at) AS invocation_started_at,
+        max(execute_completed_at) AS invocation_completed_at
+    FROM src
+    GROUP BY invocation_id, project, command, dbt_version
+),
+
+dim_proj AS (
+    SELECT project_key, project FROM {{ ref('dim_dbt_project') }}
+),
+
+fact AS (
+    SELECT
+        sha2(agg.invocation_id, 256) AS invocation_key,
+
+        -- Foreign keys
+        coalesce(dim_proj.project_key, '-1') AS project_key,
+        date_format(agg.generated_at, 'yyyyMMdd') AS date_key,
+
+        -- Degenerate dimensions
+        agg.invocation_id,
+        agg.command,
+        agg.dbt_version,
+
+        -- Measures: counts
+        agg.total_nodes,
+        agg.model_count,
+        agg.test_count,
+        agg.seed_count,
+        agg.snapshot_count,
+        agg.operation_count,
+        agg.success_count,
+        agg.error_count,
+        agg.skipped_count,
+        agg.test_pass_count,
+        agg.test_fail_count,
+        agg.test_warn_count,
+        agg.failure_count,
+
+        -- Measures: timing
+        agg.total_execution_time,
+        agg.total_execute_time,
+        agg.total_compile_time,
+        agg.avg_node_execute_time,
+        unix_timestamp(agg.invocation_completed_at) - unix_timestamp(agg.invocation_started_at) AS wall_clock_seconds,
+        agg.thread_count,
+
+        -- Measures: derived (non-additive — do not SUM)
+        CASE WHEN agg.failure_count > 0 THEN 1 ELSE 0 END AS has_failure,
+        round(agg.success_count / nullif(agg.total_nodes, 0), 4) AS success_rate,
+
+        -- Event timestamps
+        agg.invocation_started_at,
+        agg.invocation_completed_at,
+        agg.generated_at,
+
+        -- Audit + partition
+        current_timestamp() AS dbt_loaded_at,
+        date_format(current_timestamp(), 'yyyyMMdd') AS event_year_date
+
+    FROM agg
+    LEFT JOIN dim_proj ON agg.project = dim_proj.project
+)
+
+SELECT * FROM fact
+{{ fact_not_exists('invocation_key', 'fact') }}

--- a/projects/spark-dbt/dbt-dataops/models/marts/fct_dbt_node_dependency.sql
+++ b/projects/spark-dbt/dbt-dataops/models/marts/fct_dbt_node_dependency.sql
@@ -1,0 +1,78 @@
+{{
+    config(
+        materialized='table',
+        file_format='delta',
+        location_root='none',
+        partition_by=['event_year_date']
+    )
+}}
+
+-- Grain: one edge per (node_unique_id, depends_on_unique_id) for the CURRENT dbt
+-- DAG (the latest invocation per project). Rebuilt in full each run.
+
+{#
+    A dependency may point at a node that never executed on its own (e.g. a
+    source or an ephemeral node), so depends_on_node_key resolves to the -1
+    unknown member rather than dropping the edge.
+#}
+
+WITH latest_inv AS (
+    SELECT project, invocation_id
+    FROM (
+        SELECT
+            project,
+            invocation_id,
+            row_number() OVER (
+                PARTITION BY project ORDER BY generated_at DESC
+            ) AS _rn
+        FROM (
+            SELECT DISTINCT project, invocation_id, generated_at
+            FROM {{ ref('stg_dbt_node_executions') }}
+        )
+    )
+    WHERE _rn = 1
+),
+
+edges AS (
+    SELECT DISTINCT
+        dep.project,
+        dep.node_unique_id,
+        dep.depends_on_unique_id,
+        dep.run_date_key
+    FROM {{ ref('stg_dbt_node_dependency') }} AS dep
+    INNER JOIN latest_inv ON dep.invocation_id = latest_inv.invocation_id
+),
+
+dim_node AS (
+    SELECT node_key, unique_id FROM {{ ref('dim_dbt_node') }}
+),
+
+dim_proj AS (
+    SELECT project_key, project FROM {{ ref('dim_dbt_project') }}
+),
+
+fact AS (
+    SELECT
+        sha2(concat_ws('|', edges.node_unique_id, edges.depends_on_unique_id), 256) AS dependency_key,
+
+        -- Foreign keys
+        coalesce(parent.node_key, '-1') AS node_key,
+        coalesce(child.node_key, '-1') AS depends_on_node_key,
+        coalesce(dim_proj.project_key, '-1') AS project_key,
+        edges.run_date_key AS date_key,
+
+        -- Degenerate dimensions
+        edges.node_unique_id,
+        edges.depends_on_unique_id,
+
+        -- Audit + partition
+        current_timestamp() AS dbt_loaded_at,
+        date_format(current_timestamp(), 'yyyyMMdd') AS event_year_date
+
+    FROM edges
+    LEFT JOIN dim_node AS parent ON edges.node_unique_id = parent.unique_id
+    LEFT JOIN dim_node AS child ON edges.depends_on_unique_id = child.unique_id
+    LEFT JOIN dim_proj ON edges.project = dim_proj.project
+)
+
+SELECT * FROM fact

--- a/projects/spark-dbt/dbt-dataops/models/marts/fct_dbt_node_execution.sql
+++ b/projects/spark-dbt/dbt-dataops/models/marts/fct_dbt_node_execution.sql
@@ -1,0 +1,103 @@
+{{
+    config(
+        materialized='incremental',
+        incremental_strategy='append',
+        file_format='delta',
+        location_root='none',
+        on_schema_change='append_new_columns',
+        partition_by=['event_year_date']
+    )
+}}
+
+-- Grain: one row per (invocation_id, unique_id) — a single dbt node execution
+-- within one dbt invocation.
+
+WITH src AS (
+    SELECT * FROM {{ ref('stg_dbt_node_executions') }}
+    {% if is_incremental() %}
+        WHERE generated_at >= (SELECT max(generated_at) FROM {{ this }})
+    {% endif %}
+),
+
+dim_node AS (
+    SELECT node_key, unique_id FROM {{ ref('dim_dbt_node') }}
+),
+
+dim_proj AS (
+    SELECT project_key, project FROM {{ ref('dim_dbt_project') }}
+),
+
+dim_rt AS (
+    SELECT resource_type_key, resource_type FROM {{ ref('dim_dbt_resource_type') }}
+),
+
+dim_status AS (
+    SELECT status_key, status FROM {{ ref('dim_dbt_status') }}
+),
+
+dim_mat AS (
+    SELECT materialization_key, materialized FROM {{ ref('dim_dbt_materialization') }}
+),
+
+dim_tt AS (
+    SELECT test_type_key, test_type FROM {{ ref('dim_dbt_test_type') }}
+),
+
+fact AS (
+    SELECT
+        sha2(concat_ws('|', src.invocation_id, src.unique_id), 256) AS node_execution_key,
+
+        -- Foreign keys (coalesced to the -1 unknown member)
+        coalesce(dim_node.node_key, '-1') AS node_key,
+        coalesce(dim_proj.project_key, '-1') AS project_key,
+        coalesce(dim_rt.resource_type_key, '-1') AS resource_type_key,
+        coalesce(dim_status.status_key, '-1') AS status_key,
+        coalesce(dim_mat.materialization_key, '-1') AS materialization_key,
+        coalesce(dim_tt.test_type_key, '-1') AS test_type_key,
+        src.run_date_key AS date_key,
+
+        -- Degenerate dimensions
+        src.invocation_id,
+        src.unique_id,
+        src.command,
+        src.thread_id,
+        src.dbt_version,
+
+        -- Measures: timing
+        src.execution_time,
+        src.compile_time,
+        src.execute_time,
+
+        -- Measures: adapter-reported (often NULL on the fabricspark adapter)
+        src.rows_affected,
+        src.failures,
+
+        -- Measures: additive status counters
+        CASE WHEN src.is_success THEN 1 ELSE 0 END AS is_success,
+        CASE WHEN src.is_error THEN 1 ELSE 0 END AS is_error,
+        CASE WHEN src.is_skipped THEN 1 ELSE 0 END AS is_skipped,
+        CASE WHEN src.is_pass THEN 1 ELSE 0 END AS is_pass,
+        CASE WHEN src.is_fail THEN 1 ELSE 0 END AS is_fail,
+        CASE WHEN src.is_warn THEN 1 ELSE 0 END AS is_warn,
+        CASE WHEN src.has_failure THEN 1 ELSE 0 END AS has_failure,
+
+        -- Event timestamps
+        src.compile_started_at,
+        src.execute_completed_at,
+        src.generated_at,
+
+        -- Audit + partition
+        current_timestamp() AS dbt_loaded_at,
+        date_format(current_timestamp(), 'yyyyMMdd') AS event_year_date
+
+    FROM src
+    LEFT JOIN dim_node ON src.unique_id = dim_node.unique_id
+    LEFT JOIN dim_proj ON src.project = dim_proj.project
+    LEFT JOIN dim_rt ON src.resource_type = dim_rt.resource_type
+    LEFT JOIN dim_status ON src.status = dim_status.status
+    LEFT JOIN dim_mat ON src.materialized = dim_mat.materialized
+    LEFT JOIN dim_tt ON src.test_type = dim_tt.test_type
+)
+
+SELECT * FROM fact
+{{ fact_not_exists('node_execution_key', 'fact') }}

--- a/projects/spark-dbt/dbt-dataops/models/marts/obt_dbt_invocation.sql
+++ b/projects/spark-dbt/dbt-dataops/models/marts/obt_dbt_invocation.sql
@@ -1,0 +1,30 @@
+{{
+    config(
+        materialized='table',
+        file_format='delta',
+        location_root='none'
+    )
+}}
+
+-- One-big-table: fully denormalised dbt invocations joined to project + date.
+-- Grain matches fct_dbt_invocation: one row per invocation_id.
+
+with f as (
+    select * from {{ ref('fct_dbt_invocation') }}
+),
+
+d_proj as (
+    select * from {{ ref('dim_dbt_project') }}
+),
+
+d_date as (
+    select * from {{ ref('dim_date') }}
+)
+
+select
+    {{ dbt_utils.star(from=ref('fct_dbt_invocation'), relation_alias='f', except=["project_key", "date_key"]) }},
+    {{ dbt_utils.star(from=ref('dim_dbt_project'), relation_alias='d_proj', except=["project_key"]) }},
+    {{ dbt_utils.star(from=ref('dim_date'), relation_alias='d_date', except=["date_key"]) }}
+from f
+left join d_proj on f.project_key = d_proj.project_key
+left join d_date on f.date_key = d_date.date_key

--- a/projects/spark-dbt/dbt-dataops/models/marts/obt_dbt_node_execution.sql
+++ b/projects/spark-dbt/dbt-dataops/models/marts/obt_dbt_node_execution.sql
@@ -1,0 +1,64 @@
+{{
+    config(
+        materialized='table',
+        file_format='delta',
+        location_root='none'
+    )
+}}
+
+-- One-big-table: fully denormalised dbt node executions joined to every
+-- conformed dimension. Built for ad-hoc analytics / Power BI DirectLake.
+-- Grain matches fct_dbt_node_execution: one row per (invocation_id, unique_id).
+
+with f as (
+    select * from {{ ref('fct_dbt_node_execution') }}
+),
+
+d_node as (
+    select * from {{ ref('dim_dbt_node') }}
+),
+
+d_proj as (
+    select * from {{ ref('dim_dbt_project') }}
+),
+
+d_rt as (
+    select * from {{ ref('dim_dbt_resource_type') }}
+),
+
+d_status as (
+    select * from {{ ref('dim_dbt_status') }}
+),
+
+d_mat as (
+    select * from {{ ref('dim_dbt_materialization') }}
+),
+
+d_tt as (
+    select * from {{ ref('dim_dbt_test_type') }}
+),
+
+d_date as (
+    select * from {{ ref('dim_date') }}
+)
+
+select
+    {{ dbt_utils.star(from=ref('fct_dbt_node_execution'), relation_alias='f', except=[
+        "node_key", "project_key", "resource_type_key", "status_key",
+        "materialization_key", "test_type_key", "date_key"
+    ]) }},
+    {{ dbt_utils.star(from=ref('dim_dbt_node'), relation_alias='d_node', except=["node_key", "unique_id"]) }},
+    {{ dbt_utils.star(from=ref('dim_dbt_project'), relation_alias='d_proj', except=["project_key", "project"]) }},
+    {{ dbt_utils.star(from=ref('dim_dbt_resource_type'), relation_alias='d_rt', except=["resource_type_key", "resource_type", "is_test", "description"]) }},
+    {{ dbt_utils.star(from=ref('dim_dbt_status'), relation_alias='d_status', except=["status_key", "description"]) }},
+    {{ dbt_utils.star(from=ref('dim_dbt_materialization'), relation_alias='d_mat', except=["materialization_key", "materialized", "description"]) }},
+    {{ dbt_utils.star(from=ref('dim_dbt_test_type'), relation_alias='d_tt', except=["test_type_key", "test_type"]) }},
+    {{ dbt_utils.star(from=ref('dim_date'), relation_alias='d_date', except=["date_key"]) }}
+from f
+left join d_node on f.node_key = d_node.node_key
+left join d_proj on f.project_key = d_proj.project_key
+left join d_rt on f.resource_type_key = d_rt.resource_type_key
+left join d_status on f.status_key = d_status.status_key
+left join d_mat on f.materialization_key = d_mat.materialization_key
+left join d_tt on f.test_type_key = d_tt.test_type_key
+left join d_date on f.date_key = d_date.date_key

--- a/projects/spark-dbt/dbt-dataops/models/staging/_dbt_observability.yml
+++ b/projects/spark-dbt/dbt-dataops/models/staging/_dbt_observability.yml
@@ -1,0 +1,59 @@
+version: 2
+
+models:
+  - name: stg_dbt_node_executions
+    description: >-
+      Cleaned, typed, and deduplicated dbt node-execution telemetry from the
+      dataops_inventory.dbt_node_executions source. One row per
+      (invocation_id, unique_id) — the latest result per node per invocation.
+      Extracts test type / tested column / adapter message from JSON and derives
+      run date key, node layer, and boolean status flags.
+    columns:
+      - name: invocation_id
+        description: "UUID of the dbt invocation (one command run)."
+        tests:
+          - not_null
+      - name: unique_id
+        description: "Stable dbt node identity (e.g. model.dataops.dim_date)."
+        tests:
+          - not_null
+      - name: project
+        description: "dbt project name."
+        tests:
+          - not_null
+      - name: resource_type
+        description: "dbt resource type: model, test, seed, snapshot, operation."
+        tests:
+          - not_null
+      - name: status
+        description: "Raw node outcome string."
+        tests:
+          - not_null
+      - name: run_date_key
+        description: "Run date in yyyyMMdd, from coalesce(execute_completed_at, generated_at)."
+        tests:
+          - not_null
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - invocation_id
+              - unique_id
+
+  - name: stg_dbt_node_dependency
+    description: >-
+      Exploded dbt DAG edges: one row per (invocation_id, node_unique_id,
+      depends_on_unique_id) derived from the depends_on_nodes array.
+    columns:
+      - name: node_unique_id
+        description: "The dependent (parent) dbt node unique_id."
+        tests:
+          - not_null
+      - name: depends_on_unique_id
+        description: "The upstream (child) dbt node unique_id this node depends on."
+        tests:
+          - not_null
+      - name: project
+        description: "dbt project name."
+        tests:
+          - not_null

--- a/projects/spark-dbt/dbt-dataops/models/staging/_sources.yml
+++ b/projects/spark-dbt/dbt-dataops/models/staging/_sources.yml
@@ -59,3 +59,29 @@ sources:
             description: "Hive partition column in yyyyMMdd format."
           - name: result_timestamp
             description: "Event timestamp."
+
+      - name: dbt_node_executions
+        description: "dbt-runner-lib telemetry: one row per dbt node (model/test/seed/snapshot/operation) per invocation, written identically by local and Fabric runs. Partitioned by project and event_year_month (yyyyMM)."
+        columns:
+          - name: project
+            description: "dbt project name (e.g. dbt-dataops); Hive partition column."
+          - name: command
+            description: "dbt command that produced the node result (build, seed, run, test, ...)."
+          - name: invocation_id
+            description: "UUID of the dbt invocation; the natural key for one command run."
+          - name: unique_id
+            description: "Stable dbt node identity (e.g. model.dataops.dim_date)."
+          - name: resource_type
+            description: "dbt resource type: model, test, seed, snapshot, operation."
+          - name: status
+            description: "Node outcome: success/error/skipped (models), pass/fail/warn/error/skipped (tests)."
+          - name: materialized
+            description: "Node materialization: view, table, incremental, snapshot, seed, test."
+          - name: generated_at
+            description: "Invocation result generation timestamp; reliable incremental high-water mark."
+          - name: event_year_month
+            description: "Hive partition column in yyyyMM format."
+        loaded_at_field: generated_at
+        freshness:
+          warn_after: { count: 2, period: day }
+          error_after: { count: 7, period: day }

--- a/projects/spark-dbt/dbt-dataops/models/staging/stg_dbt_node_dependency.sql
+++ b/projects/spark-dbt/dbt-dataops/models/staging/stg_dbt_node_dependency.sql
@@ -1,0 +1,29 @@
+WITH nodes AS (
+    SELECT
+        invocation_id,
+        unique_id,
+        project,
+        run_date_key,
+        depends_on_nodes
+    FROM {{ ref('stg_dbt_node_executions') }}
+    WHERE depends_on_nodes IS NOT NULL AND size(depends_on_nodes) > 0
+),
+
+edges AS (
+    SELECT
+        invocation_id,
+        unique_id AS node_unique_id,
+        explode(depends_on_nodes) AS depends_on_unique_id,
+        project,
+        run_date_key
+    FROM nodes
+)
+
+SELECT
+    invocation_id,
+    node_unique_id,
+    depends_on_unique_id,
+    project,
+    run_date_key
+FROM edges
+WHERE depends_on_unique_id IS NOT NULL

--- a/projects/spark-dbt/dbt-dataops/models/staging/stg_dbt_node_executions.sql
+++ b/projects/spark-dbt/dbt-dataops/models/staging/stg_dbt_node_executions.sql
@@ -1,0 +1,88 @@
+WITH source AS (
+    SELECT * FROM {{ source('dataops_inventory', 'dbt_node_executions') }}
+),
+
+deduped AS (
+    SELECT
+        *,
+        row_number() OVER (
+            PARTITION BY invocation_id, unique_id
+            ORDER BY generated_at DESC, execute_completed_at DESC
+        ) AS _row_num
+    FROM source
+),
+
+cleaned AS (
+    SELECT
+        -- Grain keys
+        invocation_id,
+        unique_id,
+
+        -- Invocation context
+        project,
+        command,
+        dbt_version,
+        thread_id,
+        generated_at,
+
+        -- Node identity / metadata
+        resource_type,
+        package_name,
+        name AS node_name,
+        alias,
+        database AS database_name,
+        schema_name,
+        relation_name,
+        original_file_path,
+        materialized,
+
+        -- Derived node layer: folder for models, resource_type otherwise
+        CASE
+            WHEN resource_type = 'model' AND original_file_path LIKE 'models/%/%'
+                THEN split(original_file_path, '/')[1]
+            ELSE resource_type
+        END AS node_layer,
+
+        -- Test metadata (extracted from JSON)
+        get_json_object(test_metadata_json, '$.name') AS test_type,
+        coalesce(
+            get_json_object(test_metadata_json, '$.kwargs.column_name'),
+            get_json_object(test_metadata_json, '$.kwargs.key_column')
+        ) AS tested_column,
+        get_json_object(adapter_response_json, '$._message') AS adapter_message,
+
+        -- Status + boolean flags
+        status,
+        CASE WHEN status = 'success' THEN TRUE ELSE FALSE END AS is_success,
+        CASE WHEN status = 'error' THEN TRUE ELSE FALSE END AS is_error,
+        CASE WHEN status = 'skipped' THEN TRUE ELSE FALSE END AS is_skipped,
+        CASE WHEN status = 'pass' THEN TRUE ELSE FALSE END AS is_pass,
+        CASE WHEN status = 'fail' THEN TRUE ELSE FALSE END AS is_fail,
+        CASE WHEN status = 'warn' THEN TRUE ELSE FALSE END AS is_warn,
+        CASE WHEN status IN ('error', 'fail') THEN TRUE ELSE FALSE END AS has_failure,
+        CASE WHEN resource_type = 'test' THEN TRUE ELSE FALSE END AS is_test,
+
+        -- Timing measures
+        execution_time,
+        compile_time,
+        execute_time,
+        compile_started_at,
+        compile_completed_at,
+        execute_started_at,
+        execute_completed_at,
+
+        -- Adapter-reported measures (often NULL on the fabricspark adapter)
+        rows_affected,
+        failures,
+
+        -- DAG edges
+        depends_on_nodes,
+
+        -- Date + partition keys
+        date_format(coalesce(execute_completed_at, generated_at), 'yyyyMMdd') AS run_date_key,
+        event_year_month
+    FROM deduped
+    WHERE _row_num = 1
+)
+
+SELECT * FROM cleaned

--- a/projects/spark-dbt/dbt-dataops/project.json
+++ b/projects/spark-dbt/dbt-dataops/project.json
@@ -33,6 +33,13 @@
     "lint": {
       "executor": "nx:run-commands",
       "cache": false,
+      "dependsOn": [
+        {
+          "target": "init",
+          "projects": ["spark-dbt"],
+          "params": "ignore"
+        }
+      ],
       "inputs": [
         "{projectRoot}/**/*",
         "{workspaceRoot}/projects/spark-dbt/.scripts/lint-dbt.sh",

--- a/projects/spark-dbt/dbt-dataops/tests/assert_invocation_node_counts_reconcile.sql
+++ b/projects/spark-dbt/dbt-dataops/tests/assert_invocation_node_counts_reconcile.sql
@@ -1,0 +1,19 @@
+-- Custom SQL test: cross-fact reconciliation — fct_dbt_invocation.total_nodes must
+-- equal the count of fct_dbt_node_execution rows for the same invocation.
+-- Returns offending invocations (test passes only when empty).
+
+WITH node_counts AS (
+    SELECT
+        invocation_id,
+        count(*) AS node_row_count
+    FROM {{ ref('fct_dbt_node_execution') }}
+    GROUP BY invocation_id
+)
+
+SELECT
+    inv.invocation_id,
+    inv.total_nodes,
+    coalesce(node_counts.node_row_count, 0) AS node_row_count
+FROM {{ ref('fct_dbt_invocation') }} AS inv
+LEFT JOIN node_counts ON inv.invocation_id = node_counts.invocation_id
+WHERE inv.total_nodes <> coalesce(node_counts.node_row_count, 0)

--- a/projects/spark-dbt/dbt-dataops/tests/assert_node_execution_status_flags_exclusive.sql
+++ b/projects/spark-dbt/dbt-dataops/tests/assert_node_execution_status_flags_exclusive.sql
@@ -1,0 +1,14 @@
+-- Custom SQL test: the additive status flags must be mutually exclusive — a node
+-- execution has exactly one status, so at most one flag may be set.
+-- Returns offending rows (test passes only when empty).
+
+SELECT
+    node_execution_key,
+    is_success,
+    is_error,
+    is_skipped,
+    is_pass,
+    is_fail,
+    is_warn
+FROM {{ ref('fct_dbt_node_execution') }}
+WHERE (is_success + is_error + is_skipped + is_pass + is_fail + is_warn) > 1

--- a/projects/spark-dbt/dbt-dataops/tests/assert_node_execution_times_non_negative.sql
+++ b/projects/spark-dbt/dbt-dataops/tests/assert_node_execution_times_non_negative.sql
@@ -1,0 +1,13 @@
+-- Custom SQL test: node-execution timing measures must never be negative.
+-- Returns offending rows (test passes only when empty).
+
+SELECT
+    node_execution_key,
+    execution_time,
+    compile_time,
+    execute_time
+FROM {{ ref('fct_dbt_node_execution') }}
+WHERE
+    execution_time < 0
+    OR compile_time < 0
+    OR execute_time < 0

--- a/projects/spark-dbt/dbt-dataops/tests/assert_obt_rowcount_matches_fact.sql
+++ b/projects/spark-dbt/dbt-dataops/tests/assert_obt_rowcount_matches_fact.sql
@@ -1,0 +1,15 @@
+-- Custom SQL test: the denormalised OBT must not fan out or drop rows relative to
+-- its base fact — row counts must match exactly (dimension joins are 1:1 on unique
+-- surrogate keys). Returns a row only on mismatch (test passes only when empty).
+
+WITH counts AS (
+    SELECT
+        (SELECT count(*) FROM {{ ref('obt_dbt_node_execution') }}) AS obt_rows,
+        (SELECT count(*) FROM {{ ref('fct_dbt_node_execution') }}) AS fact_rows
+)
+
+SELECT
+    obt_rows,
+    fact_rows
+FROM counts
+WHERE obt_rows <> fact_rows

--- a/projects/spark-dbt/dbt-dataops/tests/generic/test_has_rows.sql
+++ b/projects/spark-dbt/dbt-dataops/tests/generic/test_has_rows.sql
@@ -1,0 +1,11 @@
+{#
+  Fails when a relation has zero rows. Apply at model level under `tests:` to
+  guard against silent emptiness (e.g. an upstream pipeline produced no data).
+#}
+{% test has_rows(model) %}
+
+SELECT 1
+FROM {{ model }}
+HAVING COUNT(*) = 0
+
+{% endtest %}

--- a/projects/spark-dbt/dbt-dataops/tests/generic/test_has_unknown_member.sql
+++ b/projects/spark-dbt/dbt-dataops/tests/generic/test_has_unknown_member.sql
@@ -1,0 +1,21 @@
+{#
+  Kimball integrity: every dimension must carry exactly one unknown member so
+  facts with an unresolved / null foreign key can resolve to it instead of
+  dropping the row. By convention the unknown member lives at
+  `<surrogate_key> = '-1'`.
+
+  Fails when a dimension has zero or more than one unknown-member row. Apply at
+  model level, passing the surrogate-key column:
+
+      tests:
+        - has_unknown_member:
+            key_column: project_key
+#}
+{% test has_unknown_member(model, key_column) %}
+
+SELECT COUNT(*) AS unknown_member_count
+FROM {{ model }}
+WHERE {{ key_column }} = '-1'
+HAVING COUNT(*) <> 1
+
+{% endtest %}

--- a/projects/spark-dbt/dbt-jaffle-shop/project.json
+++ b/projects/spark-dbt/dbt-jaffle-shop/project.json
@@ -33,6 +33,13 @@
     "lint": {
       "executor": "nx:run-commands",
       "cache": false,
+      "dependsOn": [
+        {
+          "target": "init",
+          "projects": ["spark-dbt"],
+          "params": "ignore"
+        }
+      ],
       "inputs": [
         "{projectRoot}/**/*",
         "{workspaceRoot}/projects/spark-dbt/.scripts/lint-dbt.sh",

--- a/projects/spark-dbt/dbt-reddit/project.json
+++ b/projects/spark-dbt/dbt-reddit/project.json
@@ -33,6 +33,13 @@
     "lint": {
       "executor": "nx:run-commands",
       "cache": false,
+      "dependsOn": [
+        {
+          "target": "init",
+          "projects": ["spark-dbt"],
+          "params": "ignore"
+        }
+      ],
       "inputs": [
         "{projectRoot}/**/*",
         "{workspaceRoot}/projects/spark-dbt/.scripts/lint-dbt.sh",


### PR DESCRIPTION
Closes #60

# Why this change is needed

#60 asks for a **dataops model and dashboard** over our Delta Lake / OpenLineage / dbt telemetry — including a view of *unhealthy table incidents* (à la the linked Databricks anomaly-detection pattern). This delivers an end-to-end, UI-free path from the `data_ops_inventory_db` warehouse to a published Power BI report: dbt marts → DirectLake semantic model → PBIR report.

# How

Built via the `dbt-to-power-bi` skill, reusing the existing `dbt-dataops` Kimball star schema (no new dbt project):

- **dbt observability models** (`projects/spark-dbt/dbt-dataops`): conformed dims + facts for dbt-run telemetry (`fct_dbt_node_execution`, `fct_dbt_invocation`, `dim_dbt_*`) and Delta-ops (`fct_delta_commit/storage/health`, `dim_delta_table` SCD2), with schema/FK/grain tests.
- **`dataops.SemanticModel`** (`projects/fabric/template/sandbox`): DirectLake model over the `dbt_dataops_dwh` lakehouse — 15 tables, 18 measures, 19 relationships. Cloned from the proven `adventureworks.SemanticModel` (raw dbt names as entities, inline-fact measures).
- **`dataops.Report`** (PBIR, 2 pages):
  - *dbt Pipeline Health* — KPIs, executions-over-time by status, success-rate by project, slowest-models trend, resource-type & test-family breakdowns.
  - *Delta Tables & Commits* — KPIs, commit volume by operation, storage growth, health-status mix, largest-tables trend, and an **Unhealthy Tables: Days Since Last Commit** lag chart (visual filter `status = Unhealthy`) for the incident view #60 asks for.

Considerations:
- Followed the repo's proven `adventureworks.*` clone (PBIR schemaVersion 2.7.0, DirectLake) over the skill's generic guidance, to match what publishes in this tenant.
- DirectLake points at the real `dbt_dataops_dwh` lakehouse GUID; the unused lineage mart was dropped from the model.

# Test

- **dbt**: `npx nx run dbt-dataops:test` → `PASS=199 WARN=0 ERROR=0` (build + 172 data tests: surrogate-key unique/not_null, FK relationships, grain uniqueness, cross-fact reconciliation).
- **PBIR/TMDL consistency**: all 46 visual entity/measure references resolve against the semantic model.
- **Fabric deploy**: `npx nx run fabric:deploy-fabric --ENV=dev --OPERATION=deployTemplate` → SemanticModel *and* Report `dataops` **published green** to *Sandbox - Dev - mdrrahman*.

# Checklist

- [x] Pull Request Title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Linting - ran `npx nx affected --base=origin/main -t lint --configuration=ci --verbose` locally to ensure GCI does not fail on untracked files
