### PR TITLE
fix(spark-dbt): always full-refresh seeds to avoid DELTA_CREATE_TABLE_WITH_NON_EMPTY_LOCATION flake

### DIFF
--- a/projects/fabric/template/sandbox/dbt_scheduler.Notebook/notebook-content.py
+++ b/projects/fabric/template/sandbox/dbt_scheduler.Notebook/notebook-content.py
@@ -72,7 +72,7 @@ runner:
     - command: deps
     - command: debug
     - command: seed
-      full_refresh: {FULL_REFRESH}
+      full_refresh: true
       collect_metrics: true
       copy_run_results: true
     - command: build

--- a/projects/spark-dbt/.scripts/run-dbt-local.sh
+++ b/projects/spark-dbt/.scripts/run-dbt-local.sh
@@ -80,7 +80,7 @@ runner:
     - command: deps
     - command: debug
     - command: seed
-      full_refresh: ${FR}
+      full_refresh: true
       collect_metrics: true
       copy_run_results: true
     - command: build


### PR DESCRIPTION
## Problem

Intermittent `DELTA_CREATE_TABLE_WITH_NON_EMPTY_LOCATION` failures on `dbt seed` (e.g. `person` seed in `dbt-adventureworks`). A previous seed run leaves orphan parquet files at the OneLake location without a `_delta_log`, so the next `CREATE TABLE` fails.

## Fix

Always use `full_refresh: true` on the seed pipeline step — seeds are idempotent CSVs with no incremental state, so `--full-refresh` (which DROPs first) is safe and eliminates the flake.

The `FULL_REFRESH` env var continues to control the `build` step independently.

## Changes

- `projects/spark-dbt/.scripts/run-dbt-local.sh` — seed step: `full_refresh: ${FR}` → `full_refresh: true`
- `projects/fabric/template/sandbox/dbt_scheduler.Notebook/notebook-content.py` — same